### PR TITLE
Refactoring of the _selector_serializer() function to reduce the high cognitive complexity

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -563,11 +563,6 @@ def process_select(schema: Any) -> Any:
     return {"type": "string", "enum": options}
 
 
-def process_default(schema: Any) -> Any:
-    """Handle unsupported schema."""
-    return UNSUPPORTED
-
-
 def _selector_serializer(schema: Any) -> Any:  # noqa: C901
     """Convert selectors into OpenAPI schema."""
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -497,107 +497,151 @@ def _get_exposed_entities(
     return entities
 
 
+# helper functions for _selector_serializer
+def process_colortemp(schema: Any) -> Any:
+    """Process ColorTemp selector."""
+
+    result = {"type": "number"}
+    if "min" in schema.config:
+        result["minimum"] = schema.config["min"]
+    elif "min_mireds" in schema.config:
+        result["minimum"] = schema.config["min_mireds"]
+    if "max" in schema.config:
+        result["maximum"] = schema.config["max"]
+    elif "max_mireds" in schema.config:
+        result["maximum"] = schema.config["max_mireds"]
+    return result
+
+
+def process_country(schema: Any) -> Any:
+    """Process Country selector."""
+
+    if schema.config.get("countries"):
+        return {"type": "string", "enum": schema.config["countries"]}
+    return {"type": "string", "format": "ISO 3166-1 alpha-2"}
+
+
+def process_entity(schema: Any) -> Any:
+    """Process Entity selector."""
+
+    if schema.config.get("multiple"):
+        return {"type": "array", "items": {"type": "string", "format": "entity_id"}}
+    return {"type": "string", "format": "entity_id"}
+
+
+def process_language(schema: Any) -> Any:
+    """Process Language selector."""
+
+    if schema.config.get("languages"):
+        return {"type": "string", "enum": schema.config["languages"]}
+    return {"type": "string", "format": "RFC 5646"}
+
+
+def process_number(schema: Any) -> Any:
+    """Process Number selector."""
+
+    result = {"type": "number"}
+    if "min" in schema.config:
+        result["minimum"] = schema.config["min"]
+    if "max" in schema.config:
+        result["maximum"] = schema.config["max"]
+    return result
+
+
+def process_select(schema: Any) -> Any:
+    """Process Select selector."""
+
+    options = [
+        x["value"] if isinstance(x, dict) else x for x in schema.config["options"]
+    ]
+    if schema.config.get("multiple"):
+        return {
+            "type": "array",
+            "items": {"type": "string", "enum": options},
+            "uniqueItems": True,
+        }
+    return {"type": "string", "enum": options}
+
+
+def process_default(schema: Any) -> Any:
+    """Handle unsupported schema."""
+    return UNSUPPORTED
+
+
 def _selector_serializer(schema: Any) -> Any:  # noqa: C901
     """Convert selectors into OpenAPI schema."""
+
     if not isinstance(schema, selector.Selector):
         return UNSUPPORTED
 
-    if isinstance(schema, selector.BackupLocationSelector):
-        return {"type": "string", "pattern": "^(?:\\/backup|\\w+)$"}
-
-    if isinstance(schema, selector.BooleanSelector):
-        return {"type": "boolean"}
-
-    if isinstance(schema, selector.ColorRGBSelector):
-        return {
-            "type": "array",
-            "items": {"type": "number"},
-            "minItems": 3,
-            "maxItems": 3,
-            "format": "RGB",
-        }
-
-    if isinstance(schema, selector.ConditionSelector):
-        return convert(cv.CONDITIONS_SCHEMA)
-
-    if isinstance(schema, selector.ConstantSelector):
-        return convert(vol.Schema(schema.config["value"]))
-
-    result: dict[str, Any]
-    if isinstance(schema, selector.ColorTempSelector):
-        result = {"type": "number"}
-        if "min" in schema.config:
-            result["minimum"] = schema.config["min"]
-        elif "min_mireds" in schema.config:
-            result["minimum"] = schema.config["min_mireds"]
-        if "max" in schema.config:
-            result["maximum"] = schema.config["max"]
-        elif "max_mireds" in schema.config:
-            result["maximum"] = schema.config["max_mireds"]
-        return result
-
-    if isinstance(schema, selector.CountrySelector):
-        if schema.config.get("countries"):
-            return {"type": "string", "enum": schema.config["countries"]}
-        return {"type": "string", "format": "ISO 3166-1 alpha-2"}
-
-    if isinstance(schema, selector.DateSelector):
-        return {"type": "string", "format": "date"}
-
-    if isinstance(schema, selector.DateTimeSelector):
-        return {"type": "string", "format": "date-time"}
-
-    if isinstance(schema, selector.DurationSelector):
-        return convert(cv.time_period_dict)
-
-    if isinstance(schema, selector.EntitySelector):
-        if schema.config.get("multiple"):
-            return {"type": "array", "items": {"type": "string", "format": "entity_id"}}
-
-        return {"type": "string", "format": "entity_id"}
-
-    if isinstance(schema, selector.LanguageSelector):
-        if schema.config.get("languages"):
-            return {"type": "string", "enum": schema.config["languages"]}
-        return {"type": "string", "format": "RFC 5646"}
-
-    if isinstance(schema, (selector.LocationSelector, selector.MediaSelector)):
-        return convert(schema.DATA_SCHEMA)
-
-    if isinstance(schema, selector.NumberSelector):
-        result = {"type": "number"}
-        if "min" in schema.config:
-            result["minimum"] = schema.config["min"]
-        if "max" in schema.config:
-            result["maximum"] = schema.config["max"]
-        return result
-
-    if isinstance(schema, selector.ObjectSelector):
-        return {"type": "object", "additionalProperties": True}
-
-    if isinstance(schema, selector.SelectSelector):
-        options = [
-            x["value"] if isinstance(x, dict) else x for x in schema.config["options"]
-        ]
-        if schema.config.get("multiple"):
-            return {
+    if type(schema) in [
+        selector.BackupLocationSelector,
+        selector.BooleanSelector,
+        selector.DateSelector,
+        selector.DateTimeSelector,
+        selector.ColorRGBSelector,
+        selector.ObjectSelector,
+        selector.TemplateSelector,
+        selector.TimeSelector,
+    ]:
+        simple_case_dict = {
+            selector.BackupLocationSelector: {
+                "type": "string",
+                "pattern": "^(?:\\/backup|\\w+)$",
+            },
+            selector.BooleanSelector: {"type": "boolean"},
+            selector.DateSelector: {"type": "string", "format": "date"},
+            selector.DateTimeSelector: {"type": "string", "format": "date-time"},
+            selector.ColorRGBSelector: {
                 "type": "array",
-                "items": {"type": "string", "enum": options},
-                "uniqueItems": True,
-            }
-        return {"type": "string", "enum": options}
+                "items": {"type": "number"},
+                "minItems": 3,
+                "maxItems": 3,
+                "format": "RGB",
+            },
+            selector.ObjectSelector: {"type": "object", "additionalProperties": True},
+            selector.TemplateSelector: {"type": "string", "format": "jinja2"},
+            selector.TimeSelector: {"type": "string", "format": "time"},
+        }
+        return simple_case_dict.get(type(schema))
 
-    if isinstance(schema, selector.TargetSelector):
-        return convert(cv.TARGET_SERVICE_FIELDS)
+    if type(schema) in [
+        selector.ConditionSelector,
+        selector.ConstantSelector,
+        selector.DurationSelector,
+        selector.LocationSelector,
+        selector.MediaSelector,
+        selector.TargetSelector,
+        selector.TriggerSelector,
+    ]:
+        conv_case_dict = {
+            selector.ConditionSelector: cv.CONDITIONS_SCHEMA,
+            selector.ConstantSelector: vol.Schema(schema.config["value"]),
+            selector.DurationSelector: cv.time_period_dict,
+            selector.LocationSelector: schema.DATA_SCHEMA,
+            selector.MediaSelector: schema.DATA_SCHEMA,
+            selector.TargetSelector: cv.TARGET_SERVICE_FIELDS,
+            selector.TriggerSelector: cv.TRIGGER_SCHEMA,
+        }
+        return convert(conv_case_dict.get(type(schema)))
 
-    if isinstance(schema, selector.TemplateSelector):
-        return {"type": "string", "format": "jinja2"}
-
-    if isinstance(schema, selector.TimeSelector):
-        return {"type": "string", "format": "time"}
-
-    if isinstance(schema, selector.TriggerSelector):
-        return convert(cv.TRIGGER_SCHEMA)
+    if type(schema) in [
+        selector.ColorTempSelector,
+        selector.CountrySelector,
+        selector.EntitySelector,
+        selector.LanguageSelector,
+        selector.NumberSelector,
+        selector.SelectSelector,
+    ]:
+        func_case_dict = {
+            selector.ColorTempSelector: process_colortemp,
+            selector.CountrySelector: process_country,
+            selector.EntitySelector: process_entity,
+            selector.LanguageSelector: process_language,
+            selector.NumberSelector: process_number,
+            selector.SelectSelector: process_select,
+        }
+        return func_case_dict.get(type(schema))(schema)
 
     if schema.config.get("multiple"):
         return {"type": "array", "items": {"type": "string"}}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request proposes a solution to the following issue on SonarCloud: https://sonarcloud.io/project/issues?issues=AZIJwajPpxljGap6rJks&open=AZIJwajPpxljGap6rJks&id=gaurisingh21_home-assistant-core

The found issue is relevant, because the way the code inside of the _selector_serializer() function is written induces a high cognitive complexity.
This is because the function checks the type of a given variable in a lot of if-statements, which makes the code structure difficult to read and confusing to follow.
High cognitive complexity makes it difficult for developers to implement changes and therefore increases the maintenance cost.

The proposed solution uses dictionaries instead of if-statements to handle the different procedures for every variable type.
In simple cases, the return value is directly stored in the dictionary values.
If the procedure is more complicated, a processing function is stored in the dictionary, which is then called after the corresponding variable type matches the key in the dictionary.
This way almost all if-statements can be removed, which significantly reduces the cognitive complexity of the mentioned function.

The changes have been tested successfully by running an already existing test for the _selector_serializer() in tests/helpers/test_llm.py.
Command to run the test: `pytest tests/helpers/test_llm.py`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
