### PR TITLE
Refactor mergeable 'if' statements in load(self) method

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -147,17 +147,17 @@ class Analytics:
         if (
             self.supervisor
             and (supervisor_info := hassio.get_supervisor_info(self.hass)) is not None
+            and not self.onboarded
         ):
-            if not self.onboarded:
-                # User have not configured analytics, get this setting from the supervisor
-                if supervisor_info[ATTR_DIAGNOSTICS] and not self.preferences.get(
-                    ATTR_DIAGNOSTICS, False
-                ):
-                    self._data.preferences[ATTR_DIAGNOSTICS] = True
-                elif not supervisor_info[ATTR_DIAGNOSTICS] and self.preferences.get(
-                    ATTR_DIAGNOSTICS, False
-                ):
-                    self._data.preferences[ATTR_DIAGNOSTICS] = False
+            # User have not configured analytics, get this setting from the supervisor
+            if supervisor_info[ATTR_DIAGNOSTICS] and not self.preferences.get(
+                ATTR_DIAGNOSTICS, False
+            ):
+                self._data.preferences[ATTR_DIAGNOSTICS] = True
+            elif not supervisor_info[ATTR_DIAGNOSTICS] and self.preferences.get(
+                ATTR_DIAGNOSTICS, False
+            ):
+                self._data.preferences[ATTR_DIAGNOSTICS] = False
 
     async def save_preferences(self, preferences: dict) -> None:
         """Save preferences."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed Change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR merges nested 'if' statements in _homeassistant/components/analytics/analytics.py_. The method loads previously stored user preferences and syncs them with supervisor settings. 

The selected code smell "mergeable if statements should be combined" was chosen because excessive nesting can add to the complexity of the code and reduce readability. The code smell has a medium-level impact on the system's maintainability and 45 issues in the codebase, of which 10 issues were selected for prioritisation. Issues were selected from directories changed in the last 6 months because developers have been accessing and updating these directories recently. 

The load(self) method scored the highest among the 10 issues with a total score of 21.7 and was selected for refactoring. It had 3 nesting levels, the highest of the 10 issues and one of the highest LOCs to be changed with almost 13 lines. The method had medium-range external references (5 references in 3 files). The directory was last updated a day ago from when the analysis was run making it one of the latest changed directories. In addition to the above criteria, the issue was selected because it is also testable and did not require any external hardware for testing. 

The solution was to merge the nested if-statements which reduced the nesting level of the if-block to 2 and consequently reduced the method's cognitive complexity. The second if statement's condition was merged with the first if statement because it was just extra nesting with a singular condition. Combining the inner and outer if statements did not change the logic of the code in this case. This reduced nesting could improve the readability of this method which could be useful for developers accessing and updating the directory. 

Link to Prioritisation of Issues for this Code Smell: https://docs.google.com/spreadsheets/d/1-MpvXn5vBXYutCGQ1hj9RTFUM8W7ZbjRr72V9M66Kkw/edit?gid=1747395702#gid=1747395702

Link to SonarCloud Issue: https://sonarcloud.io/project/issues?impactSeverities=MEDIUM&impactSoftwareQualities=MAINTAINABILITY&rules=python%3AS1066&issueStatuses=OPEN%2CCONFIRMED&id=gaurisingh21_home-assistant-core&open=AZIJwZYMpxljGap6rJWm

Test cases run for this change are in: **_tests/components/analytics/test_analytics.py_**
To run the test cases: **_pytest tests/components/analytics/test_analytics.py_**

![image](https://github.com/user-attachments/assets/32559045-56db-47d5-9efc-e39546cd9e86)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
