### PR TITLE
Refactor: Define a constant for 'User not found' message to eliminate duplication

### DIFF
--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -12,8 +12,10 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import Unauthorized
 
 ERROR_USER_NOT_FOUND = "User not found"
+
+
 @callback
-def asyd_setup(hass: HomeAssistant) -> bool:
+def async_setup(hass: HomeAssistant) -> bool:
     """Enable the Home Assistant views."""
     websocket_api.async_register_command(hass, websocket_create)
     websocket_api.async_register_command(hass, websocket_delete)
@@ -34,9 +36,9 @@ def asyd_setup(hass: HomeAssistant) -> bool:
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_create(
-        hass: HomeAssistant,
-        connection: websocket_api.ActiveConnection,
-        msg: dict[str, Any],
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
 ) -> None:
     """Create credentials and attach to a user."""
     provider = auth_ha.async_get_provider(hass)
@@ -72,9 +74,9 @@ async def websocket_create(
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_delete(
-        hass: HomeAssistant,
-        connection: websocket_api.ActiveConnection,
-        msg: dict[str, Any],
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
 ) -> None:
     """Delete username and related credential."""
     provider = auth_ha.async_get_provider(hass)
@@ -104,9 +106,9 @@ async def websocket_delete(
 )
 @websocket_api.async_response
 async def websocket_change_password(
-        hass: HomeAssistant,
-        connection: websocket_api.ActiveConnection,
-        msg: dict[str, Any],
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
 ) -> None:
     """Change current user password."""
     if (user := connection.user) is None:
@@ -151,9 +153,9 @@ async def websocket_change_password(
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_admin_change_password(
-        hass: HomeAssistant,
-        connection: websocket_api.ActiveConnection,
-        msg: dict[str, Any],
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
 ) -> None:
     """Change password of any user."""
     if not connection.user.is_owner:
@@ -220,4 +222,3 @@ async def websocket_admin_change_username(
 
     await provider.async_change_username(found_credential, msg["username"])
     connection.send_result(msg["id"])
-

--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -195,9 +195,9 @@ async def websocket_admin_change_password(
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_admin_change_username(
-        hass: HomeAssistant,
-        connection: websocket_api.ActiveConnection,
-        msg: dict[str, Any],
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
 ) -> None:
     """Change the username for any user."""
     if not connection.user.is_owner:

--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -11,9 +11,9 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import Unauthorized
 
-
+ERROR_USER_NOT_FOUND = "User not found"
 @callback
-def async_setup(hass: HomeAssistant) -> bool:
+def asyd_setup(hass: HomeAssistant) -> bool:
     """Enable the Home Assistant views."""
     websocket_api.async_register_command(hass, websocket_create)
     websocket_api.async_register_command(hass, websocket_delete)
@@ -34,15 +34,15 @@ def async_setup(hass: HomeAssistant) -> bool:
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_create(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
 ) -> None:
     """Create credentials and attach to a user."""
     provider = auth_ha.async_get_provider(hass)
 
     if (user := await hass.auth.async_get_user(msg["user_id"])) is None:
-        connection.send_error(msg["id"], "not_found", "User not found")
+        connection.send_error(msg["id"], "not_found", ERROR_USER_NOT_FOUND)
         return
 
     if user.system_generated:
@@ -72,9 +72,9 @@ async def websocket_create(
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_delete(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
 ) -> None:
     """Delete username and related credential."""
     provider = auth_ha.async_get_provider(hass)
@@ -104,13 +104,13 @@ async def websocket_delete(
 )
 @websocket_api.async_response
 async def websocket_change_password(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
 ) -> None:
     """Change current user password."""
     if (user := connection.user) is None:
-        connection.send_error(msg["id"], "user_not_found", "User not found")  # type: ignore[unreachable]
+        connection.send_error(msg["id"], "user_not_found", ERROR_USER_NOT_FOUND)  # type: ignore[unreachable]
         return
 
     provider = auth_ha.async_get_provider(hass)
@@ -151,16 +151,16 @@ async def websocket_change_password(
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_admin_change_password(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
 ) -> None:
     """Change password of any user."""
     if not connection.user.is_owner:
         raise Unauthorized(context=connection.context(msg))
 
     if (user := await hass.auth.async_get_user(msg["user_id"])) is None:
-        connection.send_error(msg["id"], "user_not_found", "User not found")
+        connection.send_error(msg["id"], "user_not_found", ERROR_USER_NOT_FOUND)
         return
 
     provider = auth_ha.async_get_provider(hass)
@@ -193,16 +193,16 @@ async def websocket_admin_change_password(
 @websocket_api.require_admin
 @websocket_api.async_response
 async def websocket_admin_change_username(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
 ) -> None:
     """Change the username for any user."""
     if not connection.user.is_owner:
         raise Unauthorized(context=connection.context(msg))
 
     if (user := await hass.auth.async_get_user(msg["user_id"])) is None:
-        connection.send_error(msg["id"], "user_not_found", "User not found")
+        connection.send_error(msg["id"], "user_not_found", ERROR_USER_NOT_FOUND)
         return
 
     provider = auth_ha.async_get_provider(hass)
@@ -220,3 +220,4 @@ async def websocket_admin_change_username(
 
     await provider.async_change_username(found_credential, msg["username"])
     connection.send_result(msg["id"])
+


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## What
_homeassistant/components/config/auth_provider_homeassistant.py_ was modified to replace the duplicated literal "**User not found**" error message with a `ERROR_USER_NOT_FOUND` constant.

## Why
After analysis, the “Define a constant instead of duplicating literal” code smell was selected because it had a high severity level on the maintainability of the system and 11 issues related to this code smell were selected and prioritized according to when last changes were made in the location of the issue, the approximate Lines of Code (LOC) to be changed, testability, complexity and external reference/usage of the functions in which the code smell exists.
 
This issue was prioritized because it scored the highest based on the selected criteria mentioned above with the last update on the directory a week ago. According to the analysis, this issue was introduced 3 months ago and more so, it is located in the configuration module and related to authentication in the system which makes it an important part of the system.

## Result
This change would help ensure uniformity in all functions that return the same error message and in a case where the error message needs to be changed in the future, it will only need to be updated in one line and this would improve maintainability making it easier for contributors to manage and update the code while reducing the likelihood of an error.

Also, since the directory has been recently changed, it suggests that it is frequently visited and this refactor makes it easier for contributors to make additions or modifications without breaking the flow of error reporting when a user is not found.

### Link to issue
https://sonarcloud.io/project/issues?open=AZIeWflB_pWEIrj1-0HM&id=EnguerrandINSA_home-assistant-core

**Test command**: `pytest tests/components/analytics/test_analytics.py`

![image](https://github.com/user-attachments/assets/f941b0d0-2ef5-48ce-9cce-ef781b9667b2)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
