### PR TITLE
#refactor trace_action() function to reduce cognitive complexity

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -182,7 +182,7 @@ def action_trace_append(variables: dict[str, Any], path: str) -> TraceElement:
     trace_append_element(trace_element, ACTION_TRACE_NODE_MAX_LEN)
     return trace_element
 
-
+#refactor trace_action()function to reduce cognitive complexity
 @asynccontextmanager
 async def trace_action(
     hass: HomeAssistant,
@@ -196,49 +196,8 @@ async def trace_action(
     trace_stack_push(trace_stack_cv, trace_element)
 
     trace_id = trace_id_get()
-    if trace_id:
-        key = trace_id[0]
-        run_id = trace_id[1]
-        breakpoints = hass.data[DATA_SCRIPT_BREAKPOINTS]
-        if key in breakpoints and (
-            (
-                run_id in breakpoints[key]
-                and (
-                    path in breakpoints[key][run_id]
-                    or NODE_ANY in breakpoints[key][run_id]
-                )
-            )
-            or (
-                RUN_ID_ANY in breakpoints[key]
-                and (
-                    path in breakpoints[key][RUN_ID_ANY]
-                    or NODE_ANY in breakpoints[key][RUN_ID_ANY]
-                )
-            )
-        ):
-            async_dispatcher_send_internal(
-                hass, SCRIPT_BREAKPOINT_HIT, key, run_id, path
-            )
-
-            done = hass.loop.create_future()
-
-            @callback
-            def async_continue_stop(
-                command: Literal["continue", "stop"] | None = None,
-            ) -> None:
-                if command == "stop":
-                    _set_result_unless_done(stop)
-                _set_result_unless_done(done)
-
-            signal = SCRIPT_DEBUG_CONTINUE_STOP.format(key, run_id)
-            remove_signal1 = async_dispatcher_connect(hass, signal, async_continue_stop)
-            remove_signal2 = async_dispatcher_connect(
-                hass, SCRIPT_DEBUG_CONTINUE_ALL, async_continue_stop
-            )
-
-            await asyncio.wait([stop, done], return_when=asyncio.FIRST_COMPLETED)
-            remove_signal1()
-            remove_signal2()
+    if trace_id and should_trigger_breakpoint(hass, trace_id, path):
+        await handle_breakpoint(hass, trace_id, path, stop)
 
     try:
         yield trace_element
@@ -256,6 +215,47 @@ async def trace_action(
         raise
     finally:
         trace_stack_pop(trace_stack_cv)
+
+def should_trigger_breakpoint(hass: HomeAssistant, trace_id: tuple, path: str) -> bool:
+    """Check if a breakpoint should be triggered."""
+    key, run_id = trace_id
+    breakpoints = hass.data[DATA_SCRIPT_BREAKPOINTS]
+    
+    return (
+        key in breakpoints and (
+            run_id in breakpoints[key] and (
+                path in breakpoints[key][run_id]
+                or NODE_ANY in breakpoints[key][run_id]
+            )
+            or RUN_ID_ANY in breakpoints[key] and (
+                path in breakpoints[key][RUN_ID_ANY]
+                or NODE_ANY in breakpoints[key][RUN_ID_ANY]
+            )
+        )
+    )
+
+async def handle_breakpoint(
+    hass: HomeAssistant, trace_id: tuple, path: str, stop: asyncio.Future[None]
+) -> None:
+    """Handle hitting a script breakpoint."""
+    key, run_id = trace_id
+    async_dispatcher_send_internal(hass, SCRIPT_BREAKPOINT_HIT, key, run_id, path)
+
+    done = hass.loop.create_future()
+
+    @callback
+    def async_continue_stop(command: Literal["continue", "stop"] | None = None) -> None:
+        if command == "stop":
+            _set_result_unless_done(stop)
+        _set_result_unless_done(done)
+
+    signal = SCRIPT_DEBUG_CONTINUE_STOP.format(key, run_id)
+    remove_signal1 = async_dispatcher_connect(hass, signal, async_continue_stop)
+    remove_signal2 = async_dispatcher_connect(hass, SCRIPT_DEBUG_CONTINUE_ALL, async_continue_stop)
+
+    await asyncio.wait([stop, done], return_when=asyncio.FIRST_COMPLETED)
+    remove_signal1()
+    remove_signal2()
 
 
 def make_script_schema(


### PR DESCRIPTION
<!--


## Proposed change by Nepali Poorna (Group 2)
<!--
  Changes made to reduce cognitive complexity of to below directory 

 **homeassistant/helpers/script.py directory** &  async def **trace_action()** function


We tried to encapsulates the logic for checking if a breakpoint(should_trigger_breakpoint) should be triggered while reduce the nesting level of **trace_action** by extracting helper functions.

We tried to encapsulates the handling the breakpoint logic (**handle_breakpoint**) When it is triggered which minimize the complexity in the main function.

Reduced nesting
We tried to minimize high level nesting with the help of separating the breakpoint handling logic into separate smaller functions. Further we eliminate the high-level nesting inside the main function. It helps to minimize the no. of branches & decision points within the main function. This causes to reduce cognitive complexity.

Simplified conditionals

The function called **should_trigger_breakpoint** manages all the conditional checks for breakpoints and simplifies the logic flow inside trace_action. Above changes helps code easier to maintain and reduce cognitive complexity.
-->



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
