### PR TITLE
Refactor get_dashboard_info to return a single value

### DIFF
--- a/homeassistant/components/lovelace/cast.py
+++ b/homeassistant/components/lovelace/cast.py
@@ -179,17 +179,15 @@ async def _get_dashboard_info(hass, url_path):
         "views": views,
     }
 
-    if config is None or "views" not in config:
-        return data
-
-    for idx, view in enumerate(config["views"]):
-        path = view.get("path", f"{idx}")
-        views.append(
-            {
-                "title": view.get("title", path),
-                "path": path,
-            }
-        )
+    if config is not None and "views" in config:
+        for idx, view in enumerate(config["views"]):
+            path = view.get("path", f"{idx}")
+            views.append(
+                {
+                    "title": view.get("title", path),
+                    "path": path,
+                }
+            )
 
     return data
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR solves the issue of several same value returns inside a function in _homeassistant/components/lovelace/cast.py_. This method loads a dashboard to the Home Assistant home page, and return informations on the views. 

This selected code smell "Functions return should not be invariant" was chosen because a method with several returns goes against the standards applied in Home Assistant (Pylint/PEP8). Here, the same value is return several times, increasing the complexity and reduce readability. The code smell has a high-level impact on the maintainability of the system, 71 different issues in the codebase. 10 of those issues were chosen for prioritization, all with different issue and possible solution. 

The  _"get_dashboard_info(hass, url_path)"_ function scored the highest among the 10 issues selected, with a total score of 17.5, leading to its selection for refactoring. It has a high number of external references, making it important, meaning the issue solving should be made carefully. For that, it has a medium solving complexity. The LOC to change for this issue is at a medium level. In addition to the previous criteria, this issue was selected because the method can be tested (both the functionality and the code testing), and because it does not require any additional hardware or third-party software account. 

The solution was to inverse the if block's condition, so that if the condition if not verified, the block is jumped, and the return of the value if the next line executed. The if test was _if config is None or "views" not in config_. To reverse this test, the principle of logical calculus was used: NOT (X or Y) is equivalent to NOT X and NOT Y. This allows to keep the logic of the code, while refactoring it. So we had to reverse both conditions to get this result: _if config is not None and "views" in config_. Then the return right under the if statement could be removed. This reduces the complexity of the code, while improving its readability. 

Link to SonarCloud Issue: https://sonarcloud.io/project/issues?open=AZIeWiQn_pWEIrj1-02N&id=EnguerrandINSA_home-assistant-core

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
