### PR TITLE
Global ICON_AIR_FILTER added

### DIFF
--- a/homeassistant/components/xiaomi_miio/button.py
+++ b/homeassistant/components/xiaomi_miio/button.py
@@ -30,6 +30,9 @@ from .device import XiaomiCoordinatedMiioEntity
 ATTR_RESET_DUST_FILTER = "reset_dust_filter"
 ATTR_RESET_UPPER_FILTER = "reset_upper_filter"
 
+# ICONS
+ICON_AIR_FILTER = "mdi:air-filter"
+
 # Vacuums
 METHOD_VACUUM_RESET_CONSUMABLE = "consumable_reset"
 ATTR_RESET_VACUUM_MAIN_BRUSH = "reset_vacuum_main_brush"
@@ -52,7 +55,7 @@ BUTTON_TYPES = (
     XiaomiMiioButtonDescription(
         key=ATTR_RESET_DUST_FILTER,
         name="Reset dust filter",
-        icon="mdi:air-filter",
+        icon=ICON_AIR_FILTER,
         method_press="reset_dust_filter",
         method_press_error_message="Resetting the dust filter lifetime failed",
         entity_category=EntityCategory.CONFIG,
@@ -60,7 +63,7 @@ BUTTON_TYPES = (
     XiaomiMiioButtonDescription(
         key=ATTR_RESET_UPPER_FILTER,
         name="Reset upper filter",
-        icon="mdi:air-filter",
+        icon=ICON_AIR_FILTER,
         method_press="reset_upper_filter",
         method_press_error_message="Resetting the upper filter lifetime failed.",
         entity_category=EntityCategory.CONFIG,
@@ -87,7 +90,7 @@ BUTTON_TYPES = (
     XiaomiMiioButtonDescription(
         key=ATTR_RESET_VACUUM_FILTER,
         name="Reset filter",
-        icon="mdi:air-filter",
+        icon=ICON_AIR_FILTER,
         method_press=METHOD_VACUUM_RESET_CONSUMABLE,
         method_press_params=Consumable.Filter,
         method_press_error_message="Resetting the filter lifetime failed.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request introduced a global variable for ICON_AIR_FILTER which is used at multiple locations in the same file. This will increase refactoring and readability. The issue was prioritized because of the high number of references and high number of contributers to the code.
Link to sonarcloud: https://sonarcloud.io/project/issues?directories=homeassistant%2Fcomponents%2Fxiaomi_miio&rules=python%3AS1192&issueStatuses=OPEN%2CCONFIRMED&id=salmonth_core&open=AZIe0isVX8ftgn-d5jOf
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
