### PR TITLE
Resolving String literals should not be duplicated code smell

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -343,10 +343,11 @@ class LoginFlowResourceView(LoginFlowBaseView):
 
     url = "/auth/login_flow/{flow_id}"
     name = "api:auth:login_flow:resource"
+    INVALID_FLOW_MESSAGE = "Invalid flow specified"
 
     async def get(self, request: web.Request) -> web.Response:
         """Do not allow getting status of a flow in progress."""
-        return self.json_message("Invalid flow specified", HTTPStatus.NOT_FOUND)
+        return self.json_message(self.INVALID_FLOW_MESSAGE, HTTPStatus.NOT_FOUND)
 
     @RequestDataValidator(
         vol.Schema(
@@ -371,7 +372,7 @@ class LoginFlowResourceView(LoginFlowBaseView):
                 return self.json_message("IP address changed", HTTPStatus.BAD_REQUEST)
             result = await self._flow_mgr.async_configure(flow_id, data)
         except data_entry_flow.UnknownFlow:
-            return self.json_message("Invalid flow specified", HTTPStatus.NOT_FOUND)
+            return self.json_message(self.INVALID_FLOW_MESSAGE, HTTPStatus.NOT_FOUND)
         except vol.Invalid:
             return self.json_message("User input malformed", HTTPStatus.BAD_REQUEST)
 
@@ -382,6 +383,6 @@ class LoginFlowResourceView(LoginFlowBaseView):
         try:
             self._flow_mgr.async_abort(flow_id)
         except data_entry_flow.UnknownFlow:
-            return self.json_message("Invalid flow specified", HTTPStatus.NOT_FOUND)
+            return self.json_message(self.INVALID_FLOW_MESSAGE, HTTPStatus.NOT_FOUND)
 
         return self.json_message("Flow aborted")


### PR DESCRIPTION
**The issue identified was chosen because of these issues:**

**Maintainability/Scalability:** Repeated code makes it harder to maintain the codebase. Developers must ensure every instance is updated correctly. As the system grows and more features are added, maintaining duplicate literals becomes harder to maintain. If the message needs to be updated or improved (e.g., changing it to "Flow ID not found"), there's a risk of missing an instance. if one occurrence is accidentally changed while others remain unchanged, it can lead to confusing or incorrect error messages.

**Readability:** Clean, well-structured code is easier to read and understand. Repeated strings clutter the code and make it harder to recognize patterns. A constant immediately signals that this message is a standard, reusable error message, making the code more readable.

The solution to this issue is to define a constant for the repeated string. Then, replace all instances of the string with the constant.

**Why this solution solves the Problem:**

**Maintainability:** By using a constant, the code becomes more maintainable. Future updates or modifications to the error message are easier to manage, as there’s only one place to update.

**Readability:** The use of a constant improves readability, as it signals that this error message is standard across the code. Developers can quickly see that the same message is used in multiple contexts.

**Scalability:** As the system grows, common messages should be centralized into constants or configuration files to ensure that the system remains flexible and easier to scale, making error handling or message updates much more efficient.