### PR TITLE
Empty function param code smell

### DIFF
--- a/tests/components/apple_tv/conftest.py
+++ b/tests/components/apple_tv/conftest.py
@@ -62,10 +62,10 @@ def pairing_mock() -> Generator[AsyncMock]:
         async def _pair(config, protocol, loop, session=None, **kwargs):
             return mock_pair
 
-        async def _begin():
+        async def _begin():#This is a placeholder as the pairing process doesn't require any initialization logic for testing.
             pass
 
-        async def _close():
+        async def _close():#No cleanup needed for the mock pairing process, so this is intentionally left empty.
             pass
 
         mock_pair.close.side_effect = _close

--- a/tests/components/apple_tv/conftest.py
+++ b/tests/components/apple_tv/conftest.py
@@ -62,11 +62,11 @@ def pairing_mock() -> Generator[AsyncMock]:
         async def _pair(config, protocol, loop, session=None, **kwargs):
             return mock_pair
 
-        async def _begin():#This is a placeholder as the pairing process doesn't require any initialization logic for testing.
-            pass
+        async def _begin():
+            pass #This is a placeholder as the pairing process doesn't require any initialization logic for testing.
 
-        async def _close():#No cleanup needed for the mock pairing process, so this is intentionally left empty.
-            pass
+        async def _close():
+            pass #No cleanup needed for the mock pairing process, so this is intentionally left empty.
 
         mock_pair.close.side_effect = _close
         mock_pair.begin.side_effect = _begin


### PR DESCRIPTION
Fabian Zander. Group 6.
Adresses code smell: https://sonarcloud.io/project/issues?open=AZJJKL0kIpuGhcOdwqz6&id=Maintinence_home-assistant-core&tab=how_to_fix

As stated in sonarcloud documentation "An empty method is generally considered bad practice and can lead to confusion, readability, and maintenance issues. Empty methods bring no functionality and are misleading to others as they might think the method implementation fulfills a specific and identified requirement."

Changes address a function call with empty parameters. In order to improve the readability of the code comments were added to explain the respective reasoning behind the two instances with functions being called with empty function parameters.