### PR TITLE
Solved Comparison to None should not be constant group 6

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -518,7 +518,6 @@ class ElkEntity(Entity):
 
         Currently, this method does not perform any action but serves as an extension point for further development.
         """
-        pass
 
     @callback
     def _element_callback(self, element: Element, changeset: dict[str, Any]) -> None:

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -511,6 +511,13 @@ class ElkEntity(Entity):
         return {"index": self._element.index + 1}
 
     def _element_changed(self, element: Element, changeset: dict[str, Any]) -> None:
+        """Handle changes in the element.
+
+        This method is intended to be overridden in subclasses
+        when specific behavior is needed to respond to changes in the 'Element' object.
+
+        Currently, this method does not perform any action but serves as an extension point for further development.
+        """
         pass
 
     @callback


### PR DESCRIPTION
**The issue identified was chosen because of these issues:**

**Code Intent is Unclear:** Having an empty method without any explanation makes the code's intent unclear. Future developers (or even the current developer revisiting the code later) won’t know if this method is intentionally left empty, or if it is an oversight or a placeholder for future work. This leads to confusion about whether this part of the codebase is incomplete or not.

**Risk of Errors:** If this method is expected to be overridden in subclasses or extended in the future, it should be explicitly communicated. An empty method without a clear purpose can easily be forgotten, causing issues down the line when developers expect behavior from it that doesn’t exist.

**Maintainability and Readability:** Leaving such methods unexplained reduces maintainability. Without context, it’s difficult for another developer or even yourself to know what the method was intended for, which could lead to technical debt. The lack of documentation increases the time required to understand the code in the future.

The solution to this issue is to add a comment to clearly explain why it exists in its current form. This provides clarity, communicating that the method is either intended for future development or will be overridden in subclasses, and that its current empty state is intentional.

**Why this solution solves the Problem:**

**Clarity of Intent:** The added docstring explicitly states that the method is a placeholder and explains why it's currently empty. This eliminates any ambiguity about whether the method was accidentally left unimplemented or is intentionally blank. Developers looking at this code will immediately understand that the method is meant to be overridden and extended in the future.

**Maintainability and Readability:** The documentation prevents potential confusion for developers revisiting the code in the future. Without this explanation, the presence of an empty method could lead to misunderstandings. someone might think it's a bug or an unfinished part of the code.