### PR TITLE
Fix codesmell duplicated string literal GROUP 6

### DIFF
--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -11,6 +11,8 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import Unauthorized
 
+CREDINTIALS_NOT_FOUND = "Credentials not found"
+
 
 @callback
 def async_setup(hass: HomeAssistant) -> bool:
@@ -121,9 +123,7 @@ async def websocket_change_password(
             break
 
     if username is None:
-        connection.send_error(
-            msg["id"], "credentials_not_found", "Credentials not found"
-        )
+        connection.send_error(msg["id"], "credentials_not_found", CREDINTIALS_NOT_FOUND)
         return
 
     try:
@@ -172,9 +172,7 @@ async def websocket_admin_change_password(
             break
 
     if username is None:
-        connection.send_error(
-            msg["id"], "credentials_not_found", "Credentials not found"
-        )
+        connection.send_error(msg["id"], "credentials_not_found", CREDINTIALS_NOT_FOUND)
         return
 
     await provider.async_change_password(username, msg["password"])
@@ -213,9 +211,7 @@ async def websocket_admin_change_username(
             break
 
     if found_credential is None:
-        connection.send_error(
-            msg["id"], "credentials_not_found", "Credentials not found"
-        )
+        connection.send_error(msg["id"], "credentials_not_found", CREDINTIALS_NOT_FOUND)
         return
 
     await provider.async_change_username(found_credential, msg["username"])


### PR DESCRIPTION
Hello! This is Ahmad Alkhatib and I'm part of group 6, this s the second issue I have fixed. Similar to the first issue it is a duplicated string literal. Having repetitive code decreases maintainability as the maintainers will have to alter the code in several places if they need to change the string. 

By adding a constant and using that instead of writing the string multiple time we increase the maintainability of the module in question as it allows future maintainers to more easily and quickly make changes to this string. And if more uses of this string are to appear it is easier to reuse. 

We felt that this issue is important because it fit our prioritization criteria well as well as the fact that Sonarcloud has identified this issue as HIGH severity (Similar to the first codesmell I've fixed). 