### PR TITLE
Fix empty test function

### DIFF
--- a/tests/components/folder_watcher/test_init.py
+++ b/tests/components/folder_watcher/test_init.py
@@ -34,7 +34,10 @@ def test_event() -> None:
     """Check that Home Assistant events are fired correctly on watchdog event."""
 
     class MockPatternMatchingEventHandler:
-        """Mock base class for the pattern matcher event handler."""
+        """Mock base class for the pattern matcher event handler.
+        This dummy class simulates the behaviour of the PatternMatchingEventHandler, therefore the __init__ method is purposefully empty. It is sufficient to evaluate event handler functionality.
+    """
+
 
         def __init__(self, patterns) -> None:
             pass
@@ -64,7 +67,10 @@ def test_move_event() -> None:
     """Check that Home Assistant events are fired correctly on watchdog event."""
 
     class MockPatternMatchingEventHandler:
-        """Mock base class for the pattern matcher event handler."""
+        """Mock base class for the pattern matcher event handler.
+        This dummy class simulates the behaviour of the PatternMatchingEventHandler, therefore the __init__ method is purposefully empty. It is sufficient to evaluate event handler functionality.
+    """
+
 
         def __init__(self, patterns) -> None:
             pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3452,6 +3452,11 @@ async def test_async_listen_with_run_immediately_deprecated(
     """Test async_add_job warns about its deprecation."""
 
     async def _test(event: ha.Event):
+    """
+    This function is intentionally left empty as part of a test case for 
+    deprecated functionality in Home Assistant. No additional logic is 
+    required here since it's only used to trigger a deprecation warning.
+    """
         pass
 
     func = getattr(hass.bus, method)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -197,6 +197,12 @@ async def test_async_run_hass_job_background_synchronous(hass: HomeAssistant) ->
     """Test scheduling a coro as an eager background task with async_run_hass_job."""
 
     async def job_that_does_not_suspends():
+        """
+        This function is purposefully left empty in order to replicate 
+        a synchronous task without suspending (no 'await' calls).
+        We are currently evaluating how Home Assistant handles jobs that do not suspend.
+        """
+
         pass
 
     task = hass.async_run_hass_job(
@@ -3452,11 +3458,11 @@ async def test_async_listen_with_run_immediately_deprecated(
     """Test async_add_job warns about its deprecation."""
 
     async def _test(event: ha.Event):
-    """
-    This function is intentionally left empty as part of a test case for 
-    deprecated functionality in Home Assistant. No additional logic is 
-    required here since it's only used to trigger a deprecation warning.
-    """
+        """
+        This function is intentionally left empty as part of a test case for 
+        deprecated functionality in Home Assistant. No additional logic is 
+        required here since it's only used to trigger a deprecation warning.
+        """
         pass
 
     func = getattr(hass.bus, method)


### PR DESCRIPTION


## Proposed change
This pull request resolves a code smell associated with an empty function in the Home Assistant test suite. The function 'job_that_does_not_suspends' in 'test_async_run_hass_job_background_synchronous' was deliberately left empty to imitate a synchronous job that does not suspend. A remark has been added to define the purpose of this empty function, making code more readable and eliminating possible misunderstandings for future authors.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: SonarCloud flagged code smell for lack of comments.
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
