### PR TITLE
Empty code blocks removed

### DIFF
--- a/tests/test_block_async_io.py
+++ b/tests/test_block_async_io.py
@@ -1,5 +1,4 @@
 """Tests for async util methods from Python source."""
-
 import contextlib
 import glob
 import importlib
@@ -9,20 +8,13 @@ import ssl
 import time
 from typing import Any
 from unittest.mock import Mock, patch
-
 import pytest
-
 from homeassistant import block_async_io
 from homeassistant.core import HomeAssistant
-
 from .common import extract_stack_to_frame
-
-
 @pytest.fixture(autouse=True)
 def disable_block_async_io(disable_block_async_io):
     """Disable the loop protection from block_async_io after each test."""
-
-
 async def test_protect_loop_debugger_sleep(caplog: pytest.LogCaptureFixture) -> None:
     """Test time.sleep injected by the debugger is not reported."""
     block_async_io.enable()
@@ -47,8 +39,6 @@ async def test_protect_loop_debugger_sleep(caplog: pytest.LogCaptureFixture) -> 
     ):
         time.sleep(0)  # noqa: ASYNC251
     assert "Detected blocking call inside the event loop" not in caplog.text
-
-
 async def test_protect_loop_sleep() -> None:
     """Test time.sleep not injected by the debugger raises."""
     block_async_io.enable()
@@ -73,8 +63,6 @@ async def test_protect_loop_sleep() -> None:
         ),
     ):
         time.sleep(0)  # noqa: ASYNC251
-
-
 async def test_protect_loop_sleep_get_current_frame_raises() -> None:
     """Test time.sleep when get_current_frame raises ValueError."""
     block_async_io.enable()
@@ -99,8 +87,6 @@ async def test_protect_loop_sleep_get_current_frame_raises() -> None:
         ),
     ):
         time.sleep(0)  # noqa: ASYNC251
-
-
 async def test_protect_loop_importlib_import_module_non_integration(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -128,10 +114,7 @@ async def test_protect_loop_importlib_import_module_non_integration(
         block_async_io.enable()
         with pytest.raises(ImportError):
             importlib.import_module("not_loaded_module")
-
     assert "Detected blocking call to import_module" in caplog.text
-
-
 async def test_protect_loop_importlib_import_loaded_module_non_integration(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -160,8 +143,6 @@ async def test_protect_loop_importlib_import_loaded_module_non_integration(
         importlib.import_module("sys")
 
     assert "Detected blocking call to import_module" not in caplog.text
-
-
 async def test_protect_loop_importlib_import_module_in_integration(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -205,8 +186,6 @@ async def test_protect_loop_importlib_import_module_in_integration(
         "inside the event loop by "
         "integration 'hue' at homeassistant/components/hue/light.py, line 23"
     ) in caplog.text
-
-
 async def test_protect_loop_open(caplog: pytest.LogCaptureFixture) -> None:
     """Test open of a file in /proc is not reported."""
     block_async_io.enable()
@@ -216,8 +195,6 @@ async def test_protect_loop_open(caplog: pytest.LogCaptureFixture) -> None:
     ):
         pass
     assert "Detected blocking call to open with args" not in caplog.text
-
-
 async def test_protect_loop_path_open(caplog: pytest.LogCaptureFixture) -> None:
     """Test opening a file in /proc is not reported."""
     block_async_io.enable()
@@ -227,8 +204,6 @@ async def test_protect_loop_path_open(caplog: pytest.LogCaptureFixture) -> None:
     ):
         pass
     assert "Detected blocking call to open with args" not in caplog.text
-
-
 async def test_protect_open(caplog: pytest.LogCaptureFixture) -> None:
     """Test opening a file in the event loop logs."""
     with patch.object(block_async_io, "_IN_TESTS", False):
@@ -240,8 +215,6 @@ async def test_protect_open(caplog: pytest.LogCaptureFixture) -> None:
         pass
 
     assert "Detected blocking call to open with args" in caplog.text
-
-
 async def test_protect_path_open(caplog: pytest.LogCaptureFixture) -> None:
     """Test opening a file in the event loop logs."""
     with patch.object(block_async_io, "_IN_TESTS", False):
@@ -253,8 +226,6 @@ async def test_protect_path_open(caplog: pytest.LogCaptureFixture) -> None:
         pass
 
     assert "Detected blocking call to open with args" in caplog.text
-
-
 async def test_protect_path_read_bytes(caplog: pytest.LogCaptureFixture) -> None:
     """Test reading file bytes in the event loop logs."""
     with patch.object(block_async_io, "_IN_TESTS", False):
@@ -266,8 +237,6 @@ async def test_protect_path_read_bytes(caplog: pytest.LogCaptureFixture) -> None
         pass
 
     assert "Detected blocking call to read_bytes with args" in caplog.text
-
-
 async def test_protect_path_read_text(caplog: pytest.LogCaptureFixture) -> None:
     """Test reading a file text in the event loop logs."""
     with patch.object(block_async_io, "_IN_TESTS", False):
@@ -279,8 +248,6 @@ async def test_protect_path_read_text(caplog: pytest.LogCaptureFixture) -> None:
         pass
 
     assert "Detected blocking call to read_text with args" in caplog.text
-
-
 async def test_protect_path_write_bytes(caplog: pytest.LogCaptureFixture) -> None:
     """Test writing file bytes in the event loop logs."""
     with patch.object(block_async_io, "_IN_TESTS", False):
@@ -292,8 +259,6 @@ async def test_protect_path_write_bytes(caplog: pytest.LogCaptureFixture) -> Non
         pass
 
     assert "Detected blocking call to write_bytes with args" in caplog.text
-
-
 async def test_protect_path_write_text(caplog: pytest.LogCaptureFixture) -> None:
     """Test writing file text in the event loop logs."""
     with patch.object(block_async_io, "_IN_TESTS", False):
@@ -305,8 +270,6 @@ async def test_protect_path_write_text(caplog: pytest.LogCaptureFixture) -> None
         pass
 
     assert "Detected blocking call to write_text with args" in caplog.text
-
-
 async def test_enable_multiple_times(caplog: pytest.LogCaptureFixture) -> None:
     """Test trying to enable multiple times."""
     with patch.object(block_async_io, "_IN_TESTS", False):
@@ -316,8 +279,6 @@ async def test_enable_multiple_times(caplog: pytest.LogCaptureFixture) -> None:
         RuntimeError, match="Blocking call detection is already enabled"
     ):
         block_async_io.enable()
-
-
 @pytest.mark.parametrize(
     "path",
     [
@@ -334,8 +295,6 @@ async def test_protect_open_path(path: Any, caplog: pytest.LogCaptureFixture) ->
         pass
 
     assert "Detected blocking call to open with args" in caplog.text
-
-
 async def test_protect_loop_glob(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -347,8 +306,6 @@ async def test_protect_loop_glob(
     caplog.clear()
     await hass.async_add_executor_job(glob.glob, "/dev/null")
     assert "Detected blocking call to glob with args" not in caplog.text
-
-
 async def test_protect_loop_iglob(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -360,8 +317,6 @@ async def test_protect_loop_iglob(
     caplog.clear()
     await hass.async_add_executor_job(glob.iglob, "/dev/null")
     assert "Detected blocking call to iglob with args" not in caplog.text
-
-
 async def test_protect_loop_scandir(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -375,8 +330,6 @@ async def test_protect_loop_scandir(
     with contextlib.suppress(FileNotFoundError):
         await hass.async_add_executor_job(os.scandir, "/path/that/does/not/exists")
     assert "Detected blocking call to scandir with args" not in caplog.text
-
-
 async def test_protect_loop_listdir(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -390,8 +343,6 @@ async def test_protect_loop_listdir(
     with contextlib.suppress(FileNotFoundError):
         await hass.async_add_executor_job(os.listdir, "/path/that/does/not/exists")
     assert "Detected blocking call to listdir with args" not in caplog.text
-
-
 async def test_protect_loop_walk(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -405,8 +356,6 @@ async def test_protect_loop_walk(
     with contextlib.suppress(FileNotFoundError):
         await hass.async_add_executor_job(os.walk, "/path/that/does/not/exists")
     assert "Detected blocking call to walk with args" not in caplog.text
-
-
 async def test_protect_loop_load_default_certs(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -416,8 +365,6 @@ async def test_protect_loop_load_default_certs(
     context = ssl.create_default_context()
     assert "Detected blocking call to load_default_certs" in caplog.text
     assert context
-
-
 async def test_protect_loop_load_verify_locations(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -428,8 +375,6 @@ async def test_protect_loop_load_verify_locations(
     with pytest.raises(OSError):
         context.load_verify_locations("/dev/null")
     assert "Detected blocking call to load_verify_locations" in caplog.text
-
-
 async def test_protect_loop_load_cert_chain(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -440,8 +385,6 @@ async def test_protect_loop_load_cert_chain(
     with pytest.raises(OSError):
         context.load_cert_chain("/dev/null")
     assert "Detected blocking call to load_cert_chain" in caplog.text
-
-
 async def test_open_calls_ignored_in_tests(caplog: pytest.LogCaptureFixture) -> None:
     """Test opening a file in tests is ignored."""
     assert block_async_io._IN_TESTS
@@ -451,5 +394,4 @@ async def test_open_calls_ignored_in_tests(caplog: pytest.LogCaptureFixture) -> 
         open("/config/data_not_exist", encoding="utf8"),  # noqa: ASYNC230
     ):
         pass
-
     assert "Detected blocking call to open with args" not in caplog.text

--- a/tests/test_block_async_io.py
+++ b/tests/test_block_async_io.py
@@ -394,4 +394,5 @@ async def test_open_calls_ignored_in_tests(caplog: pytest.LogCaptureFixture) -> 
         open("/config/data_not_exist", encoding="utf8"),  # noqa: ASYNC230
     ):
         pass
+
     assert "Detected blocking call to open with args" not in caplog.text


### PR DESCRIPTION
I selected this code smell because it is important to resolve for an effective maintenance. Having empty blocks of codes can be confusing to the testers as they may think either the functions are not complete or intentionally left to for a purpose. This smell can cause delay during maintenance as more time can be taken to investigate the reason behind the empty blocks. 

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
