### PR TITLE
Merge this if statement with the enclosing one

### DIFF
--- a/script/hassfest/application_credentials.py
+++ b/script/hassfest/application_credentials.py
@@ -6,7 +6,7 @@ from .model import Config, Integration
 from .serializer import format_python_namespace
 
 
-def generate_and_validate(integrations: dict[str, Integration], config: Config) -> str:
+def generate_and_validate(integrations: dict[str, Integration]) -> str:
     """Validate and generate application_credentials data."""
 
     match_list = []
@@ -28,7 +28,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         config.root / "homeassistant/generated/application_credentials.py"
     )
     config.cache["application_credentials"] = content = generate_and_validate(
-        integrations, config
+        integrations
     )
 
     if config.specific_integrations:

--- a/script/hassfest/application_credentials.py
+++ b/script/hassfest/application_credentials.py
@@ -28,7 +28,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         config.root / "homeassistant/generated/application_credentials.py"
     )
     config.cache["application_credentials"] = content = generate_and_validate(
-       integrations, config
+        integrations, config
     )
 
     if config.specific_integrations:

--- a/script/hassfest/application_credentials.py
+++ b/script/hassfest/application_credentials.py
@@ -42,7 +42,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         )
 
 
-def generate(integrations: dict[str, Integration], config: Config) -> None:
+def generate(config: Config) -> None:
     """Generate application_credentials data."""
     application_credentials_path = (
         config.root / "homeassistant/generated/application_credentials.py"

--- a/script/hassfest/application_credentials.py
+++ b/script/hassfest/application_credentials.py
@@ -6,7 +6,7 @@ from .model import Config, Integration
 from .serializer import format_python_namespace
 
 
-def generate_and_validate(integrations: dict[str, Integration]) -> str:
+def generate_and_validate(integrations: dict[str, Integration], config: Config) -> str:
     """Validate and generate application_credentials data."""
 
     match_list = []
@@ -28,7 +28,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         config.root / "homeassistant/generated/application_credentials.py"
     )
     config.cache["application_credentials"] = content = generate_and_validate(
-        integrations
+       integrations, config
     )
 
     if config.specific_integrations:
@@ -42,7 +42,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         )
 
 
-def generate(config: Config) -> None:
+def generate(integrations: dict[str, Integration], config: Config) -> None:
     """Generate application_credentials data."""
     application_credentials_path = (
         config.root / "homeassistant/generated/application_credentials.py"

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -429,9 +429,8 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
     manifests_resorted = []
     for integration in integrations.values():
         validate_manifest(integration, core_components_dir)
-        if not integration.errors:
-            if sort_manifest(integration, config):
-                manifests_resorted.append(integration.manifest_path)
+        if not integration.errors and sort_manifest(integration, config):
+            manifests_resorted.append(integration.manifest_path)
     if config.action == "generate" and manifests_resorted:
         subprocess.run(
             [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
 if statements can be combined,  the nested if statements can be put  into a single condition. 


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
By merging the two if statements into a single condition (if not integration.errors and sort_manifest(integration, config):), we address the issue of unnecessary nesting, which can make code harder to read and maintain. This code smell, caused by redundant conditional structures, can create confusion for developers trying to understand the code's intent. Each additional nested condition requires more mental effort to parse and can obscure the main logic of the function.

Combining these conditions clarifies that both not integration.errors and sort_manifest(integration, config) must be true before integration.manifest_path is appended to manifests_resorted. This not only reduces visual clutter but also highlights the logical relationship between the two conditions, making the function’s purpose and flow easier to follow.

In essence, this solution simplifies the code’s structure, improving its readability and maintainability, which are crucial for efficient future development and error reduction.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
