### PR TITLE
Media player queue, Next song functionality

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -82,6 +82,7 @@ from .const import (  # noqa: F401
     ATTR_MEDIA_PLAYLIST,
     ATTR_MEDIA_POSITION,
     ATTR_MEDIA_POSITION_UPDATED_AT,
+    ATTR_MEDIA_QUEUE,
     ATTR_MEDIA_REPEAT,
     ATTR_MEDIA_SEASON,
     ATTR_MEDIA_SEEK_POSITION,
@@ -204,6 +205,7 @@ ATTR_TO_PROPERTY = [
     ATTR_MEDIA_EPISODE,
     ATTR_MEDIA_CHANNEL,
     ATTR_MEDIA_PLAYLIST,
+    ATTR_MEDIA_QUEUE,
     ATTR_APP_ID,
     ATTR_APP_NAME,
     ATTR_INPUT_SOURCE,
@@ -478,6 +480,7 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
     "media_episode",
     "media_channel",
     "media_playlist",
+    "media_queue",
     "app_id",
     "app_name",
     "source",
@@ -518,6 +521,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_app_name: str | None = None
     _attr_device_class: MediaPlayerDeviceClass | None
     _attr_group_members: list[str] | None = None
+    _attr_media_queue: list[str] | None = None
     _attr_is_volume_muted: bool | None = None
     _attr_media_album_artist: str | None = None
     _attr_media_album_name: str | None = None
@@ -591,6 +595,11 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def is_volume_muted(self) -> bool | None:
         """Boolean if volume is currently muted."""
         return self._attr_is_volume_muted
+
+    @cached_property
+    def media_queue(self) -> list[str] | None:
+        """List of media items in the queue."""
+        return self._attr_media_queue
 
     @cached_property
     def media_content_id(self) -> str | None:

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -457,6 +457,26 @@ class MediaPlayerEntityDescription(EntityDescription, frozen_or_thawed=True):
     volume_step: float | None = None
 
 
+class MediaPlayerQueueItemCreator(TypedDict):
+    """A creator in the media player queue creators list."""
+
+    name: str | None
+    id: str | None
+    creator_type: str | None
+
+
+class MediaPlayerQueueItem(TypedDict):
+    """A single item in the media player queue."""
+
+    media_title: str | None
+    media_type: str | None
+    media_id: str | None
+    image: str | None
+    href: str | None
+    duration_ms: int | None
+    media_creators: list[MediaPlayerQueueItemCreator] | None
+
+
 CACHED_PROPERTIES_WITH_ATTR_ = {
     "device_class",
     "state",
@@ -521,7 +541,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_app_name: str | None = None
     _attr_device_class: MediaPlayerDeviceClass | None
     _attr_group_members: list[str] | None = None
-    _attr_media_queue: list[str] | None = None
+    _attr_media_queue: list[MediaPlayerQueueItem] | None = None
     _attr_is_volume_muted: bool | None = None
     _attr_media_album_artist: str | None = None
     _attr_media_album_name: str | None = None
@@ -597,7 +617,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return self._attr_is_volume_muted
 
     @cached_property
-    def media_queue(self) -> list[str] | None:
+    def media_queue(self) -> list[MediaPlayerQueueItem] | None:
         """List of media items in the queue."""
         return self._attr_media_queue
 

--- a/homeassistant/components/media_player/const.py
+++ b/homeassistant/components/media_player/const.py
@@ -23,6 +23,7 @@ ATTR_MEDIA_ENQUEUE = "enqueue"
 ATTR_MEDIA_EXTRA = "extra"
 ATTR_MEDIA_EPISODE = "media_episode"
 ATTR_MEDIA_PLAYLIST = "media_playlist"
+ATTR_MEDIA_QUEUE = "media_queue"
 ATTR_MEDIA_POSITION = "media_position"
 ATTR_MEDIA_POSITION_UPDATED_AT = "media_position_updated_at"
 ATTR_MEDIA_REPEAT = "repeat"
@@ -200,6 +201,8 @@ class MediaPlayerEntityFeature(IntFlag):
     GROUPING = 524288
     MEDIA_ANNOUNCE = 1048576
     MEDIA_ENQUEUE = 2097152
+
+    MEDIA_QUEUE = 4194304
 
 
 # These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -51,6 +51,7 @@ SUPPORT_SPOTIFY = (
     | MediaPlayerEntityFeature.SELECT_SOURCE
     | MediaPlayerEntityFeature.SHUFFLE_SET
     | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.MEDIA_QUEUE
 )
 
 REPEAT_MODE_MAPPING_TO_HA = {
@@ -129,6 +130,7 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         self.data = data
 
         self._attr_unique_id = user_id
+        self._queue = ["hejsan!:)"]
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, user_id)},
@@ -166,6 +168,13 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         if not self._currently_playing:
             return None
         return self._currently_playing.get("device", {}).get("volume_percent", 0) / 100
+
+    @property
+    def media_queue(self) -> list[str] | None:
+        """Return the media queue."""
+        if self._queue is None:
+            return None
+        return self._queue
 
     @property
     def media_content_id(self) -> str | None:

--- a/homeassistant/components/spotify/util.py
+++ b/homeassistant/components/spotify/util.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import yarl
 
+from homeassistant.components.media_player import MediaPlayerQueueItem
+
 from .const import MEDIA_PLAYER_PREFIX
 
 
@@ -33,3 +35,35 @@ def spotify_uri_from_media_browser_url(media_content_id: str) -> str:
         parsed_url = yarl.URL(media_content_id)
         media_content_id = parsed_url.name
     return media_content_id
+
+
+def format_queue(
+    spotify_queue_response: dict[str, Any] | None,
+) -> list[MediaPlayerQueueItem]:
+    """Format the queue response."""
+
+    if spotify_queue_response is None:
+        return []
+
+    unfiltered_queue = spotify_queue_response.get("queue", [])
+
+    return [
+        {
+            "media_title": item.get("name", None),
+            "media_type": item.get("type", None),
+            "media_id": item.get("id", None),
+            "image": item.get("album", {}).get("images", [{}])[0].get("url", None),
+            "href": item.get("href", None),
+            "duration_ms": item.get("duration_ms", None),
+            "media_creators": [
+                {
+                    "name": creator.get("name", None),
+                    "id": creator.get("id", None),
+                    "creator_type": creator.get("type", None),
+                }
+                for creator in item.get("artists", [])
+            ]
+            or None,
+        }
+        for item in unfiltered_queue
+    ]

--- a/tests/components/spotify/test_media_player_queue.py
+++ b/tests/components/spotify/test_media_player_queue.py
@@ -1,0 +1,109 @@
+from unittest.mock import Mock  # noqa: D100
+
+import pytest
+
+from homeassistant.components.spotify.media_player import SpotifyMediaPlayer
+from homeassistant.components.spotify.util import format_queue
+
+
+@pytest.fixture
+def mock_spotify_data():
+    """Mock HomeAssistantSpotifyData with fake data."""
+
+    mock_data = Mock()
+    mock_data.current_user = {"product": "premium"}
+
+    mock_data.client = Mock()
+    return mock_data
+
+
+@pytest.fixture
+def mock_raw_queue():
+    """Provide raw queue data from thr spotify web api to be used for testing."""
+    return {
+        "queue": [
+            {
+                "album": {
+                    "album_type": "single",
+                    "total_tracks": 1,
+                    "href": "https://api.spotify.com/v1/albums/test",
+                    "id": "test",
+                    "name": "test song",
+                    "release_date": "2024-10-11",
+                    "release_date_precision": "day",
+                    "type": "album",
+                    "uri": "spotify:album:test",
+                    "artists": [
+                        {
+                            "external_urls": {
+                                "spotify": "https://open.spotify.com/artist/test"
+                            },
+                            "href": "https://api.spotify.com/v1/artists/test",
+                            "id": "test",
+                            "name": "testArtist",
+                            "type": "artist",
+                            "uri": "spotify:artist:test",
+                        },
+                        {
+                            "external_urls": {
+                                "spotify": "https://open.spotify.com/artist/test"
+                            },
+                            "href": "https://api.spotify.com/v1/artists/test",
+                            "id": "test",
+                            "name": "testArtist2",
+                            "type": "artist",
+                            "uri": "spotify:artist:test",
+                        },
+                    ],
+                },
+                "artists": [
+                    {
+                        "href": "https://api.spotify.com/v1/artists/test",
+                        "id": "test",
+                        "name": "testArtist",
+                        "type": "artist",
+                        "uri": "spotify:artist:test",
+                    },
+                    {
+                        "external_urls": {
+                            "spotify": "https://open.spotify.com/artist/test"
+                        },
+                        "href": "https://api.spotify.com/v1/artists/test",
+                        "id": "test",
+                        "name": "testArtist2",
+                        "type": "artist",
+                        "uri": "spotify:artist:test",
+                    },
+                ],
+                "available_markets": [
+                    "NONE",
+                ],
+                "href": "https://api.spotify.com/v1/tracks/test",
+                "id": "test",
+                "name": "test song",
+                "popularity": 60,
+                "track_number": 1,
+                "type": "track",
+                "uri": "spotify:track:test",
+            },
+        ]
+    }
+
+
+def test_media_queue(
+    mock_spotify_data: Mock, mock_raw_queue: dict[str, list[dict[str, str | int]]]
+) -> None:
+    """Test the SpotifyMediaPlayer media queue formatting."""
+    mock_spotify_data.client.queue.return_value = mock_raw_queue
+
+    media_player = SpotifyMediaPlayer(
+        data=mock_spotify_data,
+        user_id="mock_user_id",
+        name="Mock User",
+    )
+
+    formatted_queue = media_player._queue = format_queue(
+        mock_spotify_data.client.queue()
+    )
+
+    assert formatted_queue[0]["media_title"] == "test song"


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added a queue property to the media player. This queue property is currently used to show which the next media in the queue is. Future features could be displaying the whole queue for the media player. Together with a contribution to the general media_player, a contribution to the spotify media_player has also been made where the user's queue is fetched and formatted to show the functionality of the new contribution. This contribution requires the correct frontend to work properly (branch: frontend-next, https://github.com/Grupp-9-Evolution/home-assistant-frontend/tree/frontend-next).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
