### PR TITLE
defined constant for the error string

### DIFF
--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -195,6 +195,9 @@ FAN_DIRECTIONS_MAP = {
     "reverse": "left",
 }
 
+# Defining constants:
+SET_OPERATION_MODE_FAILED: str = "Setting operation mode of the miio device failed."
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -525,7 +528,7 @@ class XiaomiAirPurifier(XiaomiGenericAirPurifier):
         )
         if speed_mode:
             await self._try_command(
-                "Setting operation mode of the miio device failed.",
+                SET_OPERATION_MODE_FAILED,
                 self._device.set_mode,
                 self.operation_mode_class(self.SPEED_MODE_MAPPING[speed_mode]),
             )
@@ -536,7 +539,7 @@ class XiaomiAirPurifier(XiaomiGenericAirPurifier):
         This method is a coroutine.
         """
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OPERATION_MODE_FAILED,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -630,7 +633,7 @@ class XiaomiAirPurifierMB4(XiaomiGenericAirPurifier):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OPERATION_MODE_FAILED,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -713,7 +716,7 @@ class XiaomiAirFresh(XiaomiGenericAirPurifier):
         )
         if speed_mode:
             if await self._try_command(
-                "Setting operation mode of the miio device failed.",
+                SET_OPERATION_MODE_FAILED,
                 self._device.set_mode,
                 AirfreshOperationMode(self.SPEED_MODE_MAPPING[speed_mode]),
             ):
@@ -728,7 +731,7 @@ class XiaomiAirFresh(XiaomiGenericAirPurifier):
         This method is a coroutine.
         """
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OPERATION_MODE_FAILED,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -816,7 +819,7 @@ class XiaomiAirFreshA1(XiaomiGenericAirPurifier):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan. This method is a coroutine."""
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OPERATION_MODE_FAILED,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -1038,7 +1041,7 @@ class XiaomiFanP5(XiaomiGenericFan):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OPERATION_MODE_FAILED,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         )
@@ -1094,7 +1097,7 @@ class XiaomiFanMiot(XiaomiGenericFan):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OPERATION_MODE_FAILED,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
When passing the arguments for the function `_try_command()` the string `"Setting operation mode of the miio device failed."`
is being repeatedly duplicated each time the function is called. In order to ensure good maintainability, a constant `SET_OPERATION_MODE_FAILED` has been defined. This makes it much easier for the developer in the future, if the string were to change, then it doesn't have to be changed in all eight instances.

Sonarcloud issue: https://sonarcloud.io/project/issues?directories=homeassistant%2Fcomponents%2Fxiaomi_miio&rules=python%3AS1192&issueStatuses=OPEN%2CCONFIRMED&id=salmonth_core&open=AZIe0iqbX8ftgn-d5jOH

Note: This is the same PR as https://github.com/PA2558-SEMP/home-assistant-core/pull/66 but since the PR had two different aims, they have now been split.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
