### PR TITLE
The second if condition has merged with the first using and

### DIFF
--- a/homeassistant/components/smlight/coordinator.py
+++ b/homeassistant/components/smlight/coordinator.py
@@ -43,11 +43,11 @@ class SmDataUpdateCoordinator(DataUpdateCoordinator[SmData]):
 
     async def _async_setup(self) -> None:
         """Authenticate if needed during initial setup."""
-        if await self.client.check_auth_needed():
-            if (
-                CONF_USERNAME in self.config_entry.data
-                and CONF_PASSWORD in self.config_entry.data
-            ):
+        if await self.client.check_auth_needed() and (
+    CONF_USERNAME in self.config_entry.data
+    and CONF_PASSWORD in self.config_entry.data
+):
+
                 try:
                     await self.client.authenticate(
                         self.config_entry.data[CONF_USERNAME],


### PR DESCRIPTION
Proposed change
Refactored Nested if Statements:

The nested if statement was merged into a single conditional using and. This eliminates unnecessary nesting and improves the readability and maintainability of the code.
Why This Refactor Matters:

Improved Code Clarity: Combining the conditions makes the logic easier to follow, reducing cognitive load for future maintainers.
Better Maintainability: By reducing indentation levels, the code is less prone to errors during future modifications or extensions.
Adherence to Best Practices: The refactor aligns with clean code principles and eliminates the python:S1066 code smell (mergeable if statements).
Functionality Unchanged:

This refactor preserves the original behavior: authentication is attempted only if check_auth_needed returns True and both CONF_USERNAME and CONF_PASSWORD exist in config_entry.data.

Conclusion:
This refactor resolves a general maintainability issue rather than a specific bug or feature request. However, improving code readability and structure reduces the likelihood of bugs in future updates.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

