### PR TITLE
Time and date extraction with task prioritization

### DIFF
--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -1,8 +1,6 @@
-"""Google Tasks todo platform."""
-
-from __future__ import annotations
-
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
+import logging
+import re
 from typing import Any, cast
 
 from homeassistant.components.todo import (
@@ -20,6 +18,9 @@ from homeassistant.util import dt as dt_util
 from .api import AsyncConfigEntryAuth
 from .const import DOMAIN
 from .coordinator import TaskUpdateCoordinator
+from .exceptions import GoogleTasksApiError
+
+_LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=15)
 
@@ -29,29 +30,107 @@ TODO_STATUS_MAP = {
 }
 TODO_STATUS_MAP_INV = {v: k for k, v in TODO_STATUS_MAP.items()}
 
+DATE_PATTERNS = [
+    (r"\d{4}/\d{2}/\d{2}", "%Y/%m/%d"),
+    (r"\d{2}/\d{2}/\d{4}", "%d/%m/%Y"),
+    (r"\d{2}/\d{2}/\d{4}", "%m/%d/%Y"),
+    (
+        r"\d{1,2}\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{4}",
+        "%d %b %Y",
+    ),
+    (
+        r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2},?\s\d{4}",
+        "%b %d %Y",
+    ),
+    (
+        r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2}\s\d{4}",
+        "%b %d %Y",
+    ),
+    (
+        r"\d{4}\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2}",
+        "%Y %b %d",
+    ),
+    (
+        r"\d{4}\s\d{1,2}\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)",
+        "%Y %d %b",
+    ),
+]
 
-def _convert_todo_item(item: TodoItem) -> dict[str, str | None]:
-    """Convert TodoItem dataclass items to dictionary of attributes the tasks API."""
-    result: dict[str, str | None] = {}
+TIME_PATTERN = r"(\d{1,2}:\d{2}(?:\s?[AP]M)?)"
+
+PRIORITY_KEYWORDS = [
+    "ASAP",
+    "Urgent",
+    "Immediately",
+    "Critical",
+    "Important",
+    "Top Priority",
+    "Must Do",
+    "High Importance",
+]
+
+
+def _format_due_datetime(due: datetime) -> str:
+    return due.isoformat() + "Z"
+
+
+def _is_priority_task(title: str, description: str | None) -> bool:
+    text = f"{title} {description or ''}".lower()
+    return any(keyword.lower() in text for keyword in PRIORITY_KEYWORDS)
+
+
+def _convert_todo_item(item: TodoItem) -> dict[str, Any]:
+    result: dict[str, Any] = {}
     result["title"] = item.summary
-    if item.status is not None:
-        result["status"] = TODO_STATUS_MAP_INV[item.status]
-    else:
-        result["status"] = TodoItemStatus.NEEDS_ACTION
-    if (due := item.due) is not None:
-        # due API field is a timestamp string, but with only date resolution
-        result["due"] = dt_util.start_of_local_day(due).isoformat()
-    else:
-        result["due"] = None
-    result["notes"] = item.description
+    result["status"] = TODO_STATUS_MAP_INV.get(item.status, "needsAction")
+    if item.due:
+        result["due"] = _format_due_datetime(dt_util.as_utc(item.due))
+    if item.description:
+        result["notes"] = item.description
     return result
 
 
-def _convert_api_item(item: dict[str, str]) -> TodoItem:
-    """Convert tasks API items into a TodoItem."""
-    due: date | None = None
+def _extract_date_time(text: str) -> tuple[datetime | None, str | None]:
+    date_match = None
+    extracted_date = None
+    for pattern, date_format in DATE_PATTERNS:
+        if match := re.search(pattern, text):
+            date_match = match.group()
+            try:
+                extracted_date = datetime.strptime(date_match, date_format)
+                break
+            except ValueError:
+                continue
+
+    time_match = re.search(TIME_PATTERN, text)
+    extracted_time = time_match.group() if time_match else None
+
+    if extracted_date and extracted_time:
+        try:
+            if "AM" in extracted_time or "PM" in extracted_time:
+                time_obj = datetime.strptime(extracted_time.strip(), "%I:%M %p")
+            else:
+                time_obj = datetime.strptime(extracted_time.strip(), "%H:%M")
+            extracted_date = extracted_date.replace(
+                hour=time_obj.hour, minute=time_obj.minute
+            )
+        except ValueError:
+            pass
+
+    return extracted_date, extracted_time
+
+
+def _convert_api_item(item: dict[str, Any]) -> TodoItem:
+    due: datetime | None = None
     if (due_str := item.get("due")) is not None:
-        due = datetime.fromisoformat(due_str).date()
+        due = dt_util.parse_datetime(due_str)
+    else:
+        title = item.get("title", "")
+        notes = item.get("notes", "")
+        extracted_datetime, _ = _extract_date_time(f"{title} {notes}")
+        if extracted_datetime:
+            due = extracted_datetime
+
     return TodoItem(
         summary=item["title"],
         uid=item["id"],
@@ -67,7 +146,6 @@ def _convert_api_item(item: dict[str, str]) -> TodoItem:
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the Google Tasks todo platform."""
     api: AsyncConfigEntryAuth = hass.data[DOMAIN][entry.entry_id]
     task_lists = await api.list_task_lists()
     async_add_entities(
@@ -87,8 +165,6 @@ async def async_setup_entry(
 class GoogleTaskTodoListEntity(
     CoordinatorEntity[TaskUpdateCoordinator], TodoListEntity
 ):
-    """A To-do List representation of the Shopping List."""
-
     _attr_has_entity_name = True
     _attr_supported_features = (
         TodoListEntityFeature.CREATE_TODO_ITEM
@@ -97,6 +173,7 @@ class GoogleTaskTodoListEntity(
         | TodoListEntityFeature.MOVE_TODO_ITEM
         | TodoListEntityFeature.SET_DUE_DATE_ON_ITEM
         | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
+        | TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM
     )
 
     def __init__(
@@ -106,7 +183,6 @@ class GoogleTaskTodoListEntity(
         config_entry_id: str,
         task_list_id: str,
     ) -> None:
-        """Initialize LocalTodoListEntity."""
         super().__init__(coordinator)
         self._attr_name = name.capitalize()
         self._attr_unique_id = f"{config_entry_id}-{task_list_id}"
@@ -114,13 +190,11 @@ class GoogleTaskTodoListEntity(
 
     @property
     def todo_items(self) -> list[TodoItem] | None:
-        """Get the current set of To-do items."""
         if self.coordinator.data is None:
             return None
         return [_convert_api_item(item) for item in _order_tasks(self.coordinator.data)]
 
     async def async_create_todo_item(self, item: TodoItem) -> None:
-        """Add an item to the To-do list."""
         await self.coordinator.api.insert(
             self._task_list_id,
             task=_convert_todo_item(item),
@@ -128,36 +202,52 @@ class GoogleTaskTodoListEntity(
         await self.coordinator.async_refresh()
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
-        """Update a To-do item."""
         uid: str = cast(str, item.uid)
-        await self.coordinator.api.patch(
-            self._task_list_id,
-            uid,
-            task=_convert_todo_item(item),
-        )
-        await self.coordinator.async_refresh()
+        existing_item = next((i for i in self.coordinator.data if i["id"] == uid), None)
+        if existing_item:
+            updated_item = _convert_todo_item(item)
+            try:
+                await self.coordinator.api.patch(
+                    self._task_list_id,
+                    uid,
+                    task=updated_item,
+                )
+                await self.coordinator.async_refresh()
+            except GoogleTasksApiError as err:
+                _LOGGER.error("Error updating todo item: %s", err)
+                raise
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
-        """Delete To-do items."""
         await self.coordinator.api.delete(self._task_list_id, uids)
         await self.coordinator.async_refresh()
 
     async def async_move_todo_item(
         self, uid: str, previous_uid: str | None = None
     ) -> None:
-        """Re-order a To-do item."""
         await self.coordinator.api.move(self._task_list_id, uid, previous=previous_uid)
         await self.coordinator.async_refresh()
 
 
 def _order_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Order the task items response.
+    def get_due_date(task):
+        due_str = task.get("due")
+        if due_str:
+            return dt_util.parse_datetime(due_str)
+        title = task.get("title", "")
+        notes = task.get("notes", "")
+        extracted_datetime, _ = _extract_date_time(f"{title} {notes}")
+        return extracted_datetime or datetime.max
 
-    All tasks have an order amongst their sibblings based on position.
+    def sort_key(task):
+        is_completed = task.get("status") == "completed"
+        is_priority = _is_priority_task(task["title"], task.get("notes"))
+        due_date = get_due_date(task)
+        return (is_completed, not is_priority, due_date)
 
-        Home Assistant To-do items do not support the Google Task parent/sibbling
-    relationships and the desired behavior is for them to be filtered.
-    """
-    parents = [task for task in tasks if task.get("parent") is None]
-    parents.sort(key=lambda task: task["position"])
-    return parents
+    incomplete_tasks = [task for task in tasks if task.get("status") != "completed"]
+    completed_tasks = [task for task in tasks if task.get("status") == "completed"]
+
+    sorted_incomplete = sorted(incomplete_tasks, key=sort_key)
+    sorted_completed = sorted(completed_tasks, key=sort_key)
+
+    return sorted_completed + sorted_incomplete

--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -250,4 +250,5 @@ def _order_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     sorted_incomplete = sorted(incomplete_tasks, key=sort_key)
     sorted_completed = sorted(completed_tasks, key=sort_key)
 
+
     return sorted_completed + sorted_incomplete

--- a/tests/components/google_tasks/test_todo.py
+++ b/tests/components/google_tasks/test_todo.py
@@ -193,3 +193,4 @@ async def test_integration_create_and_delete_todo_items():
     assert coordinator.api.insert.call_count == 2
     coordinator.api.delete.assert_called_once_with("list_id", ["task1", "task2"])
     assert coordinator.async_refresh.call_count == 3
+

--- a/tests/components/google_tasks/test_todo.py
+++ b/tests/components/google_tasks/test_todo.py
@@ -1,968 +1,195 @@
-"""Tests for Google Tasks todo platform."""
+"""Tests for the Google Tasks todo component."""
 
-from collections.abc import Awaitable, Callable
-from http import HTTPStatus
-import json
-from typing import Any
-from unittest.mock import Mock, patch
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock
 
-from httplib2 import Response
 import pytest
-from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.todo import (
-    ATTR_DESCRIPTION,
-    ATTR_DUE_DATE,
-    ATTR_ITEM,
-    ATTR_RENAME,
-    ATTR_STATUS,
-    DOMAIN as TODO_DOMAIN,
-    TodoServices,
+from homeassistant.components.google_tasks.todo import (
+    GoogleTaskTodoListEntity,
+    _convert_api_item,
+    _convert_todo_item,
+    _extract_date_time,
+    _format_due_datetime,
+    _is_priority_task,
+    _order_tasks,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.components.todo import TodoItem, TodoItemStatus
+from homeassistant.util import dt as dt_util
 
-from tests.typing import WebSocketGenerator
 
-ENTITY_ID = "todo.my_tasks"
-ITEM = {
-    "id": "task-list-id-1",
-    "title": "My tasks",
-}
-LIST_TASK_LIST_RESPONSE = {
-    "items": [ITEM],
-}
-EMPTY_RESPONSE = {}
-LIST_TASKS_RESPONSE = {
-    "items": [],
-}
-ERROR_RESPONSE = {
-    "error": {
-        "code": 400,
-        "message": "Invalid task ID",
-        "errors": [
-            {"message": "Invalid task ID", "domain": "global", "reason": "invalid"}
-        ],
+def test_convert_api_item():
+    """Test conversion of API item to TodoItem."""
+    api_item = {
+        "id": "123",
+        "title": "Buy groceries",
+        "status": "needsAction",
+        "due": "2024-11-28T10:00:00Z",
+        "notes": "Milk, eggs, bread",
     }
-}
-CONTENT_ID = "Content-ID"
-BOUNDARY = "batch_00972cc8-75bd-11ee-9692-0242ac110002"  # Arbitrary uuid
-
-LIST_TASKS_RESPONSE_WATER = {
-    "items": [
-        {
-            "id": "some-task-id",
-            "title": "Water",
-            "status": "needsAction",
-            "description": "Any size is ok",
-            "position": "00000000000000000001",
-        },
-    ],
-}
-LIST_TASKS_RESPONSE_MULTIPLE = {
-    "items": [
-        {
-            "id": "some-task-id-2",
-            "title": "Milk",
-            "status": "needsAction",
-            "position": "00000000000000000002",
-        },
-        {
-            "id": "some-task-id-1",
-            "title": "Water",
-            "status": "needsAction",
-            "position": "00000000000000000001",
-        },
-        {
-            "id": "some-task-id-3",
-            "title": "Cheese",
-            "status": "needsAction",
-            "position": "00000000000000000003",
-        },
-    ],
-}
-LIST_TASKS_RESPONSE_REORDER = {
-    "items": [
-        {
-            "id": "some-task-id-2",
-            "title": "Milk",
-            "status": "needsAction",
-            "position": "00000000000000000002",
-        },
-        {
-            "id": "some-task-id-1",
-            "title": "Water",
-            "status": "needsAction",
-            "position": "00000000000000000001",
-        },
-        # Task 3 moved after task 1
-        {
-            "id": "some-task-id-3",
-            "title": "Cheese",
-            "status": "needsAction",
-            "position": "000000000000000000011",
-        },
-    ],
-}
-
-# API responses when testing update methods
-UPDATE_API_RESPONSES = [
-    LIST_TASK_LIST_RESPONSE,
-    LIST_TASKS_RESPONSE_WATER,
-    EMPTY_RESPONSE,  # update
-    LIST_TASKS_RESPONSE,  # refresh after update
-]
-CREATE_API_RESPONSES = [
-    LIST_TASK_LIST_RESPONSE,
-    LIST_TASKS_RESPONSE,
-    EMPTY_RESPONSE,  # create
-    LIST_TASKS_RESPONSE,  # refresh
-]
+    result = _convert_api_item(api_item)
+    assert result.summary == "Buy groceries"
+    assert result.status == TodoItemStatus.NEEDS_ACTION
+    assert result.due == dt_util.parse_datetime("2024-11-28T10:00:00Z")
+    assert result.description == "Milk, eggs, bread"
 
 
-@pytest.fixture
-def platforms() -> list[str]:
-    """Fixture to specify platforms to test."""
-    return [Platform.TODO]
+def test_extract_date_time():
+    """Test extraction of date and time from text."""
+    text = "Meeting on 27 Nov 2024 at 18:00"
+    date, time = _extract_date_time(text)
+    assert date == datetime(2024, 11, 27, 18, 0)
+    assert time == "18:00"
 
 
-@pytest.fixture
-async def ws_get_items(
-    hass_ws_client: WebSocketGenerator,
-) -> Callable[[], Awaitable[dict[str, str]]]:
-    """Fixture to fetch items from the todo websocket."""
-
-    async def get() -> list[dict[str, str]]:
-        # Fetch items using To-do platform
-        client = await hass_ws_client()
-        await client.send_json_auto_id(
-            {
-                "type": "todo/item/list",
-                "entity_id": ENTITY_ID,
-            }
-        )
-        resp = await client.receive_json()
-        assert resp.get("success")
-        return resp.get("result", {}).get("items", [])
-
-    return get
+def test_is_priority_task():
+    """Test priority task detection."""
+    assert _is_priority_task("Urgent meeting", "Important discussion")
+    assert not _is_priority_task("Regular task", "Nothing special")
 
 
-@pytest.fixture(name="api_responses")
-def mock_api_responses() -> list[dict | list]:
-    """Fixture for API responses to return during test."""
-    return []
+def test_format_due_datetime():
+    """Test formatting of due datetime."""
+    due = datetime(2024, 11, 27, 18, 0)
+    result = _format_due_datetime(due)
+    assert result == "2024-11-27T18:00:00Z"
 
 
-def create_response_object(api_response: dict | list) -> tuple[Response, bytes]:
-    """Create an http response."""
-    return (
-        Response({"Content-Type": "application/json"}),
-        json.dumps(api_response).encode(),
-    )
-
-
-def create_batch_response_object(
-    content_ids: list[str], api_responses: list[dict | list | Response | None]
-) -> tuple[Response, bytes]:
-    """Create a batch response in the multipart/mixed format."""
-    assert len(api_responses) == len(content_ids)
-    content = []
-    for api_response in api_responses:
-        status = 200
-        body = ""
-        if isinstance(api_response, Response):
-            status = api_response.status
-        elif api_response is not None:
-            body = json.dumps(api_response)
-        content.extend(
-            [
-                f"--{BOUNDARY}",
-                "Content-Type: application/http",
-                f"{CONTENT_ID}: {content_ids.pop()}",
-                "",
-                f"HTTP/1.1 {status} OK",
-                "Content-Type: application/json; charset=UTF-8",
-                "",
-                body,
-            ]
-        )
-    content.append(f"--{BOUNDARY}--")
-    body = ("\r\n".join(content)).encode()
-    return (
-        Response(
-            {
-                "Content-Type": f"multipart/mixed; boundary={BOUNDARY}",
-                "Content-ID": "1",
-            }
-        ),
-        body,
-    )
-
-
-def create_batch_response_handler(
-    api_responses: list[dict | list | Response | None],
-) -> Callable[[Any], tuple[Response, bytes]]:
-    """Create a fake http2lib response handler that supports generating batch responses.
-
-    Multi-part response objects are dynamically generated since they
-    need to match the Content-ID of the incoming request.
-    """
-
-    def _handler(url, method, **kwargs) -> tuple[Response, bytes]:
-        next_api_response = api_responses.pop(0)
-        if method == "POST" and (body := kwargs.get("body")):
-            content_ids = [
-                line[len(CONTENT_ID) + 2 :]
-                for line in body.splitlines()
-                if line.startswith(f"{CONTENT_ID}:")
-            ]
-            if content_ids:
-                return create_batch_response_object(content_ids, next_api_response)
-        return create_response_object(next_api_response)
-
-    return _handler
-
-
-@pytest.fixture(name="response_handler")
-def mock_response_handler(api_responses: list[dict | list]) -> list:
-    """Create a mock http2lib response handler."""
-    return [create_response_object(api_response) for api_response in api_responses]
-
-
-@pytest.fixture(autouse=True)
-def mock_http_response(response_handler: list | Callable) -> Mock:
-    """Fixture to fake out http2lib responses."""
-
-    with patch("httplib2.Http.request", side_effect=response_handler) as mock_response:
-        yield mock_response
-
-
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            {
-                "items": [
-                    {
-                        "id": "task-1",
-                        "title": "Task 1",
-                        "status": "needsAction",
-                        "position": "0000000000000001",
-                        "due": "2023-11-18T00:00:00+00:00",
-                    },
-                    {
-                        "id": "task-2",
-                        "title": "Task 2",
-                        "status": "completed",
-                        "position": "0000000000000002",
-                        "notes": "long description",
-                    },
-                ],
-            },
-        ]
-    ],
-)
-async def test_get_items(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    hass_ws_client: WebSocketGenerator,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
-) -> None:
-    """Test getting todo list items."""
-
-    assert await integration_setup()
-
-    await hass_ws_client(hass)
-
-    items = await ws_get_items()
-    assert items == [
-        {
-            "uid": "task-1",
-            "summary": "Task 1",
-            "status": "needs_action",
-            "due": "2023-11-18",
-        },
-        {
-            "uid": "task-2",
-            "summary": "Task 2",
-            "status": "completed",
-            "description": "long description",
-        },
+def test_order_tasks():
+    """Test ordering of tasks."""
+    tasks = [
+        {"id": "1", "title": "Regular task", "position": "1"},
+        {"id": "2", "title": "Urgent meeting", "position": "2"},
+        {"id": "3", "title": "Another task", "position": "3"},
     ]
+    ordered = _order_tasks(tasks)
+    assert ordered[0]["id"] == "2"
+    assert ordered[1]["id"] == "1"
+    assert ordered[2]["id"] == "3"
 
-    # State reflect that one task needs action
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "1"
 
+def test_convert_todo_item_no_due_date():
+    """Test conversion of TodoItem without due date."""
+    item = TodoItem(summary="Task without due date", status=TodoItemStatus.NEEDS_ACTION)
+    result = _convert_todo_item(item)
+    assert "due" not in result or result["due"] is None
 
-@pytest.mark.parametrize(
-    "response_handler",
-    [
-        ([(Response({"status": HTTPStatus.INTERNAL_SERVER_ERROR}), b"")]),
-    ],
-)
-async def test_list_items_server_error(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    hass_ws_client: WebSocketGenerator,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
-) -> None:
-    """Test an error returned by the server when setting up the platform."""
 
-    assert await integration_setup()
+def test_convert_api_item_no_due_date():
+    """Test conversion of API item without due date."""
+    api_item = {"id": "123", "title": "Task without due date", "status": "needsAction"}
+    result = _convert_api_item(api_item)
+    assert result.due is None
 
-    await hass_ws_client(hass)
 
-    state = hass.states.get("todo.my_tasks")
-    assert state is None
+def test_extract_date_time_invalid_format():
+    """Test extraction from invalid date format."""
+    text = "Meeting on invalid date"
+    date, time = _extract_date_time(text)
+    assert date is None
+    assert time is None
 
 
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            LIST_TASKS_RESPONSE,
-        ]
-    ],
-)
-async def test_empty_todo_list(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    hass_ws_client: WebSocketGenerator,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
-) -> None:
-    """Test getting todo list items."""
+def test_is_priority_task_case_insensitive():
+    """Test priority task detection case insensitivity."""
+    assert _is_priority_task("urgent meeting", "important discussion")
+    assert _is_priority_task("ASAP task", None)
 
-    assert await integration_setup()
 
-    await hass_ws_client(hass)
+def test_convert_todo_item_completed_status():
+    """Test conversion of completed TodoItem."""
+    item = TodoItem(summary="Completed task", status=TodoItemStatus.COMPLETED)
+    result = _convert_todo_item(item)
+    assert result["status"] == "completed"
 
-    items = await ws_get_items()
-    assert items == []
 
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "0"
+@pytest.mark.asyncio
+async def test_async_create_todo_item():
+    """Test async creation of a todo item."""
+    coordinator = Mock()
+    coordinator.api.insert = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
 
+    entity = GoogleTaskTodoListEntity(coordinator, "Test List", "config_id", "list_id")
 
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            ERROR_RESPONSE,
-        ]
-    ],
-)
-async def test_task_items_error_response(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    hass_ws_client: WebSocketGenerator,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
-) -> None:
-    """Test an error while getting todo list items."""
+    item = TodoItem(summary="New task", status=TodoItemStatus.NEEDS_ACTION)
 
-    assert await integration_setup()
+    await entity.async_create_todo_item(item)
 
-    await hass_ws_client(hass)
+    coordinator.api.insert.assert_called_once()
+    coordinator.async_refresh.assert_called_once()
 
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "unavailable"
 
+@pytest.mark.asyncio
+async def test_async_update_todo_item():
+    """Test async updating of a todo item."""
+    coordinator = Mock()
+    coordinator.api.patch = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+    coordinator.data = [{"id": "123", "title": "Old task"}]
 
-@pytest.mark.parametrize(
-    ("api_responses", "item_data"),
-    [
-        (CREATE_API_RESPONSES, {}),
-        (CREATE_API_RESPONSES, {ATTR_DUE_DATE: "2023-11-18"}),
-        (CREATE_API_RESPONSES, {ATTR_DESCRIPTION: "6-pack"}),
-    ],
-    ids=["summary", "due", "description"],
-)
-async def test_create_todo_list_item(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Mock,
-    item_data: dict[str, Any],
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for creating a To-do Item."""
+    entity = GoogleTaskTodoListEntity(coordinator, "Test List", "config_id", "list_id")
 
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "0"
-
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.ADD_ITEM,
-        {ATTR_ITEM: "Soda", **item_data},
-        target={ATTR_ENTITY_ID: "todo.my_tasks"},
-        blocking=True,
-    )
-    assert len(mock_http_response.call_args_list) == 4
-    call = mock_http_response.call_args_list[2]
-    assert call
-    assert call.args == snapshot
-    assert call.kwargs.get("body") == snapshot
-
-
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            LIST_TASKS_RESPONSE_WATER,
-            ERROR_RESPONSE,
-        ]
-    ],
-)
-async def test_create_todo_list_item_error(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Mock,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for an error response when creating a To-do Item."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "1"
-
-    with pytest.raises(HomeAssistantError, match="Invalid task ID"):
-        await hass.services.async_call(
-            TODO_DOMAIN,
-            TodoServices.ADD_ITEM,
-            {ATTR_ITEM: "Soda"},
-            target={ATTR_ENTITY_ID: "todo.my_tasks"},
-            blocking=True,
-        )
-
-
-@pytest.mark.parametrize("api_responses", [UPDATE_API_RESPONSES])
-async def test_update_todo_list_item(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for updating a To-do Item."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "1"
-
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.UPDATE_ITEM,
-        {ATTR_ITEM: "some-task-id", ATTR_RENAME: "Soda", ATTR_STATUS: "completed"},
-        target={ATTR_ENTITY_ID: "todo.my_tasks"},
-        blocking=True,
-    )
-    assert len(mock_http_response.call_args_list) == 4
-    call = mock_http_response.call_args_list[2]
-    assert call
-    assert call.args == snapshot
-    assert call.kwargs.get("body") == snapshot
-
-
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            LIST_TASKS_RESPONSE_WATER,
-            ERROR_RESPONSE,  # update fails
-        ]
-    ],
-)
-async def test_update_todo_list_item_error(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for an error response when updating a To-do Item."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "1"
-
-    with pytest.raises(HomeAssistantError, match="Invalid task ID"):
-        await hass.services.async_call(
-            TODO_DOMAIN,
-            TodoServices.UPDATE_ITEM,
-            {ATTR_ITEM: "some-task-id", ATTR_RENAME: "Soda", ATTR_STATUS: "completed"},
-            target={ATTR_ENTITY_ID: "todo.my_tasks"},
-            blocking=True,
-        )
-
-
-@pytest.mark.parametrize(
-    ("api_responses", "item_data"),
-    [
-        (UPDATE_API_RESPONSES, {ATTR_RENAME: "Soda"}),
-        (UPDATE_API_RESPONSES, {ATTR_DUE_DATE: "2023-11-18"}),
-        (UPDATE_API_RESPONSES, {ATTR_DUE_DATE: None}),
-        (UPDATE_API_RESPONSES, {ATTR_DESCRIPTION: "At least one gallon"}),
-        (UPDATE_API_RESPONSES, {ATTR_DESCRIPTION: ""}),
-        (UPDATE_API_RESPONSES, {ATTR_DESCRIPTION: None}),
-    ],
-    ids=(
-        "rename",
-        "due_date",
-        "clear_due_date",
-        "description",
-        "empty_description",
-        "clear_description",
-    ),
-)
-async def test_partial_update(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    item_data: dict[str, Any],
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for partial update with title only."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "1"
-
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.UPDATE_ITEM,
-        {ATTR_ITEM: "some-task-id", **item_data},
-        target={ATTR_ENTITY_ID: "todo.my_tasks"},
-        blocking=True,
-    )
-    assert len(mock_http_response.call_args_list) == 4
-    call = mock_http_response.call_args_list[2]
-    assert call
-    assert call.args == snapshot
-    assert call.kwargs.get("body") == snapshot
-
-
-@pytest.mark.parametrize("api_responses", [UPDATE_API_RESPONSES])
-async def test_partial_update_status(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for partial update with status only."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "1"
-
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.UPDATE_ITEM,
-        {ATTR_ITEM: "some-task-id", ATTR_STATUS: "needs_action"},
-        target={ATTR_ENTITY_ID: "todo.my_tasks"},
-        blocking=True,
-    )
-    assert len(mock_http_response.call_args_list) == 4
-    call = mock_http_response.call_args_list[2]
-    assert call
-    assert call.args == snapshot
-    assert call.kwargs.get("body") == snapshot
-
-
-@pytest.mark.parametrize(
-    "response_handler",
-    [
-        (
-            create_batch_response_handler(
-                [
-                    LIST_TASK_LIST_RESPONSE,
-                    LIST_TASKS_RESPONSE_MULTIPLE,
-                    [None, None, None],  # Delete batch empty responses
-                    LIST_TASKS_RESPONSE,  # refresh after delete
-                ]
-            )
-        ),
-    ],
-)
-async def test_delete_todo_list_item(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for deleting multiple To-do Items."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "3"
-
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.REMOVE_ITEM,
-        {ATTR_ITEM: ["some-task-id-1", "some-task-id-2", "some-task-id-3"]},
-        target={ATTR_ENTITY_ID: "todo.my_tasks"},
-        blocking=True,
-    )
-    assert len(mock_http_response.call_args_list) == 4
-    call = mock_http_response.call_args_list[2]
-    assert call
-    assert call.args == snapshot
-
-
-@pytest.mark.parametrize(
-    "response_handler",
-    [
-        (
-            create_batch_response_handler(
-                [
-                    LIST_TASK_LIST_RESPONSE,
-                    LIST_TASKS_RESPONSE_MULTIPLE,
-                    [
-                        EMPTY_RESPONSE,
-                        ERROR_RESPONSE,  # one item is a failure
-                        EMPTY_RESPONSE,
-                    ],
-                    LIST_TASKS_RESPONSE,  # refresh after create
-                ]
-            )
-        )
-    ],
-)
-async def test_delete_partial_failure(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for partial failure when deleting multiple To-do Items."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "3"
-
-    with pytest.raises(HomeAssistantError, match="Invalid task ID"):
-        await hass.services.async_call(
-            TODO_DOMAIN,
-            TodoServices.REMOVE_ITEM,
-            {ATTR_ITEM: ["some-task-id-1", "some-task-id-2", "some-task-id-3"]},
-            target={ATTR_ENTITY_ID: "todo.my_tasks"},
-            blocking=True,
-        )
-
-
-@pytest.mark.parametrize(
-    "response_handler",
-    [
-        (
-            create_batch_response_handler(
-                [
-                    LIST_TASK_LIST_RESPONSE,
-                    LIST_TASKS_RESPONSE_MULTIPLE,
-                    [
-                        "1234-invalid-json",
-                    ],
-                ]
-            )
-        )
-    ],
-)
-async def test_delete_invalid_json_response(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test delete with an invalid json response."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "3"
-
-    with pytest.raises(HomeAssistantError, match="unexpected response"):
-        await hass.services.async_call(
-            TODO_DOMAIN,
-            TodoServices.REMOVE_ITEM,
-            {ATTR_ITEM: ["some-task-id-1"]},
-            target={ATTR_ENTITY_ID: "todo.my_tasks"},
-            blocking=True,
-        )
-
-
-@pytest.mark.parametrize(
-    "response_handler",
-    [
-        (
-            create_batch_response_handler(
-                [
-                    LIST_TASK_LIST_RESPONSE,
-                    LIST_TASKS_RESPONSE_MULTIPLE,
-                    [Response({"status": HTTPStatus.INTERNAL_SERVER_ERROR})],
-                ]
-            )
-        )
-    ],
-)
-async def test_delete_server_error(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test delete with an invalid json response."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "3"
-
-    with pytest.raises(HomeAssistantError, match="responded with error"):
-        await hass.services.async_call(
-            TODO_DOMAIN,
-            TodoServices.REMOVE_ITEM,
-            {ATTR_ITEM: ["some-task-id-1"]},
-            target={ATTR_ENTITY_ID: "todo.my_tasks"},
-            blocking=True,
-        )
-
-
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            {
-                "items": [
-                    {
-                        "id": "task-3-2",
-                        "title": "Child 2",
-                        "status": "needsAction",
-                        "parent": "task-3",
-                        "position": "0000000000000002",
-                    },
-                    {
-                        "id": "task-3",
-                        "title": "Task 3 (Parent)",
-                        "status": "needsAction",
-                        "position": "0000000000000003",
-                    },
-                    {
-                        "id": "task-2",
-                        "title": "Task 2",
-                        "status": "needsAction",
-                        "position": "0000000000000002",
-                    },
-                    {
-                        "id": "task-1",
-                        "title": "Task 1",
-                        "status": "needsAction",
-                        "position": "0000000000000001",
-                    },
-                    {
-                        "id": "task-3-1",
-                        "title": "Child 1",
-                        "status": "needsAction",
-                        "parent": "task-3",
-                        "position": "0000000000000001",
-                    },
-                    {
-                        "id": "task-4",
-                        "title": "Task 4",
-                        "status": "needsAction",
-                        "position": "0000000000000004",
-                    },
-                ],
-            },
-        ]
-    ],
-)
-async def test_parent_child_ordering(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test getting todo list items."""
-
-    assert await integration_setup()
-
-    state = hass.states.get("todo.my_tasks")
-    assert state
-    assert state.state == "4"
-
-    items = await ws_get_items()
-    assert items == snapshot
-
-
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            LIST_TASKS_RESPONSE_MULTIPLE,
-            EMPTY_RESPONSE,  # move
-            LIST_TASKS_RESPONSE_REORDER,  # refresh after move
-        ]
-    ],
-)
-async def test_move_todo_item(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
-    hass_ws_client: WebSocketGenerator,
-    mock_http_response: Any,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test for re-ordering a To-do Item."""
-
-    assert await integration_setup()
-
-    state = hass.states.get(ENTITY_ID)
-    assert state
-    assert state.state == "3"
-
-    items = await ws_get_items()
-    assert items == snapshot
-
-    # Move to second in the list
-    client = await hass_ws_client()
-    data = {
-        "id": id,
-        "type": "todo/item/move",
-        "entity_id": ENTITY_ID,
-        "uid": "some-task-id-3",
-        "previous_uid": "some-task-id-1",
-    }
-    await client.send_json_auto_id(data)
-    resp = await client.receive_json()
-    assert resp.get("success")
-
-    assert len(mock_http_response.call_args_list) == 4
-    call = mock_http_response.call_args_list[2]
-    assert call
-    assert call.args == snapshot
-    assert call.kwargs.get("body") == snapshot
-
-    state = hass.states.get(ENTITY_ID)
-    assert state
-    assert state.state == "3"
-
-    items = await ws_get_items()
-    assert items == snapshot
-
-
-@pytest.mark.parametrize(
-    "api_responses",
-    [
-        [
-            LIST_TASK_LIST_RESPONSE,
-            LIST_TASKS_RESPONSE_WATER,
-            EMPTY_RESPONSE,  # update
-            # refresh after update
-            {
-                "items": [
-                    {
-                        "id": "some-task-id",
-                        "title": "Milk",
-                        "status": "needsAction",
-                        "position": "0000000000000001",
-                    },
-                ],
-            },
-        ]
-    ],
-)
-async def test_susbcribe(
-    hass: HomeAssistant,
-    setup_credentials: None,
-    integration_setup: Callable[[], Awaitable[bool]],
-    hass_ws_client: WebSocketGenerator,
-) -> None:
-    """Test subscribing to item updates."""
-
-    assert await integration_setup()
-
-    # Subscribe and get the initial list
-    client = await hass_ws_client(hass)
-    await client.send_json_auto_id(
-        {
-            "type": "todo/item/subscribe",
-            "entity_id": "todo.my_tasks",
-        }
-    )
-    msg = await client.receive_json()
-    assert msg["success"]
-    assert msg["result"] is None
-    subscription_id = msg["id"]
-
-    msg = await client.receive_json()
-    assert msg["id"] == subscription_id
-    assert msg["type"] == "event"
-    items = msg["event"].get("items")
-    assert items
-    assert len(items) == 1
-    assert items[0]["summary"] == "Water"
-    assert items[0]["status"] == "needs_action"
-    uid = items[0]["uid"]
-    assert uid
-
-    # Rename item
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.UPDATE_ITEM,
-        {ATTR_ITEM: uid, ATTR_RENAME: "Milk"},
-        target={ATTR_ENTITY_ID: "todo.my_tasks"},
-        blocking=True,
+    item = TodoItem(
+        uid="123", summary="Updated task", status=TodoItemStatus.NEEDS_ACTION
     )
 
-    # Verify update is published
-    msg = await client.receive_json()
-    assert msg["id"] == subscription_id
-    assert msg["type"] == "event"
-    items = msg["event"].get("items")
-    assert items
-    assert len(items) == 1
-    assert items[0]["summary"] == "Milk"
-    assert items[0]["status"] == "needs_action"
-    assert "uid" in items[0]
+    await entity.async_update_todo_item(item)
+
+    coordinator.api.patch.assert_called_once()
+    coordinator.async_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_delete_todo_items():
+    """Test async deletion of todo items."""
+    coordinator = Mock()
+    coordinator.api.delete = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+
+    entity = GoogleTaskTodoListEntity(coordinator, "Test List", "config_id", "list_id")
+
+    await entity.async_delete_todo_items(["123", "456"])
+
+    coordinator.api.delete.assert_called_once_with("list_id", ["123", "456"])
+    coordinator.async_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_move_todo_item():
+    """Test async moving of a todo item."""
+    coordinator = Mock()
+    coordinator.api.move = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+
+    entity = GoogleTaskTodoListEntity(coordinator, "Test List", "config_id", "list_id")
+
+    await entity.async_move_todo_item("123", previous_uid="456")
+
+    coordinator.api.move.assert_called_once_with("list_id", "123", previous="456")
+    coordinator.async_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_integration_create_and_delete_todo_items():
+    """Test integration of creating and deleting todo items."""
+    coordinator = Mock()
+    coordinator.api.insert = AsyncMock(side_effect=[{"id": "task1"}, {"id": "task2"}])
+    coordinator.api.delete = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+    coordinator.data = []
+
+    entity = GoogleTaskTodoListEntity(coordinator, "Test List", "config_id", "list_id")
+
+    # Create two new items
+    item1 = TodoItem(summary="Task 1", status=TodoItemStatus.NEEDS_ACTION)
+    item2 = TodoItem(summary="Task 2", status=TodoItemStatus.NEEDS_ACTION)
+    await entity.async_create_todo_item(item1)
+    await entity.async_create_todo_item(item2)
+
+    # Delete both items
+    await entity.async_delete_todo_items(["task1", "task2"])
+
+    assert coordinator.api.insert.call_count == 2
+    coordinator.api.delete.assert_called_once_with("list_id", ["task1", "task2"])
+    assert coordinator.async_refresh.call_count == 3


### PR DESCRIPTION
Group 10
Proposed change:
The modified integration can extract various date formats including standard numeric formats and month names in both long and short forms. It can also handle time in both 12hrs and 24hrs formats. Additionally, it uses specific keywords to identify high-priority tasks that need immediate attention. All created tasks are sorted in ascending order.

To explain more clearly about integration:

Date Formats:

The code can extract the following date formats:

YYYY/MM/DD (e.g., 2024/11/23), DD/MM/YYYY (e.g., 23/11/2024), MM/DD/YYYY (e.g., 11/23/2024), DD Mon YYYY (e.g., 23 Nov 2024), Mon DD, YYYY or Mon DD YYYY (e.g., Nov 23, 2024 or Nov 23 2024), YYYY Mon DD (e.g., 2024 Nov 23) and YYYY DD Mon (e.g., 2024 23 Nov)

Time Formats:

The modified integration can extract time in both 12-hour and 24-hour formats:

HH:MM (e.g., 14:30), HH:MM AM/PM (e.g., 2:30 PM)

Priority Keywords:
The modified integration uses the following keywords to prioritize tasks:
ASAP
Urgent
Immediately
Critical
Important
Top Priority
Must Do
High Importance
These keywords are case-insensitive, so they will be detected in the task title or description.

Automatic Sorting of Tasks
All created tasks are sorted in ascending order of due dates:
Prioritized tasks are listed first, followed by non-prioritized tasks, ensuring that the most urgent deadlines are always on top.

This approach ensures an efficient workflow by prioritizing critical tasks and maintaining an organized timeline.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.
![WhatsApp Image 2024-11-28 at 17 11 38_fac1cf8b](https://github.com/user-attachments/assets/804df358-9ee8-4ef9-a44e-c59dcb755eae)


