### PR TITLE
constant STATUSLIGHTON instead of literal "status-light-on"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ config2/*
 
 tests/testing_config/deps
 tests/testing_config/home-assistant.log*
+dembaEnv/
+homeassistant-venv/
+myNewEnv/
 
 # hass-release
 data/

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -37,7 +37,7 @@ from .entity import (
 from .models import PermRequired, ProtectEntityDescription, ProtectEventMixin
 
 _KEY_DOOR = "door"
-
+STATUSLIGHTON="Status light on"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ProtectBinaryEntityDescription(
@@ -78,7 +78,7 @@ CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ),
     ProtectBinaryEntityDescription(
         key="status_light",
-        name="Status light on",
+        name=STATUSLIGHTON,
         icon="mdi:led-on",
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_required_field="feature_flags.has_led_status",
@@ -321,7 +321,7 @@ LIGHT_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ),
     ProtectBinaryEntityDescription(
         key="status_light",
-        name="Status light on",
+        name=STATUSLIGHTON,
         icon="mdi:led-on",
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="light_device_settings.is_indicator_enabled",
@@ -371,7 +371,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ),
     ProtectBinaryEntityDescription(
         key="status_light",
-        name="Status light on",
+        name=STATUSLIGHTON,
         icon="mdi:led-on",
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="led_settings.is_enabled",
@@ -580,7 +580,7 @@ DOORLOCK_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ),
     ProtectBinaryEntityDescription(
         key="status_light",
-        name="Status light on",
+        name=STATUSLIGHTON,
         icon="mdi:led-on",
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="led_settings.is_enabled",

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -38,7 +38,7 @@ from .models import PermRequired, ProtectEntityDescription, ProtectEventMixin
 
 _KEY_DOOR = "door"
 STATUSLIGHTON="Status light on"
-
+MDILEDON="mdi:led-on"
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ProtectBinaryEntityDescription(
     ProtectEntityDescription, BinarySensorEntityDescription
@@ -79,7 +79,7 @@ CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         name=STATUSLIGHTON,
-        icon="mdi:led-on",
+        icon=MDILEDON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_required_field="feature_flags.has_led_status",
         ufp_value="led_settings.is_enabled",
@@ -322,7 +322,7 @@ LIGHT_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         name=STATUSLIGHTON,
-        icon="mdi:led-on",
+        icon=MDILEDON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="light_device_settings.is_indicator_enabled",
         ufp_perm=PermRequired.NO_WRITE,
@@ -372,7 +372,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         name=STATUSLIGHTON,
-        icon="mdi:led-on",
+        icon=MDILEDON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="led_settings.is_enabled",
         ufp_perm=PermRequired.NO_WRITE,
@@ -581,7 +581,7 @@ DOORLOCK_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="status_light",
         name=STATUSLIGHTON,
-        icon="mdi:led-on",
+        icon=MDILEDON,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="led_settings.is_enabled",
         ufp_perm=PermRequired.NO_WRITE,

--- a/script/hassfest/application_credentials.py
+++ b/script/hassfest/application_credentials.py
@@ -6,7 +6,7 @@ from .model import Config, Integration
 from .serializer import format_python_namespace
 
 
-def generate_and_validate(integrations: dict[str, Integration], config: Config) -> str:
+def generate_and_validate(integrations: dict[str, Integration]) -> str:
     """Validate and generate application_credentials data."""
 
     match_list = []
@@ -28,7 +28,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         config.root / "homeassistant/generated/application_credentials.py"
     )
     config.cache["application_credentials"] = content = generate_and_validate(
-        integrations, config
+        integrations
     )
 
     if config.specific_integrations:

--- a/script/hassfest/application_credentials.py
+++ b/script/hassfest/application_credentials.py
@@ -6,9 +6,9 @@ from .model import Config, Integration
 from .serializer import format_python_namespace
 
 
-def generate_and_validate(integrations: dict[str, Integration]) -> str:
+def generate_and_validate(integrations: dict[str, Integration], config: Config) -> str:
     """Validate and generate application_credentials data."""
-
+    _ = config
     match_list = []
 
     for domain in sorted(integrations):
@@ -28,7 +28,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
         config.root / "homeassistant/generated/application_credentials.py"
     )
     config.cache["application_credentials"] = content = generate_and_validate(
-        integrations
+        integrations, config
     )
 
     if config.specific_integrations:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
according to the code analysis we have done, the duplication of the same literal several times affects maintainability possible to create inconsistencies and errors when changes need to be done.  Moreover, code duplication violates DRY (Do not Repeat Yourself) principle which is not a decent practice in coding. The change merged in this pull request, contains the fix for the issue which got the most priority in our analysis based on maintenance criteria. All the issues identified in the selected directory (homeassistant/components/unifiprotect/binary_sensor.py) have same time effort 2 minutes for each repetition. The file inusemnet is same so the only difference is the number of repeatition has been occured. each literal which have been repited more tha 3 time will be refactore.

The selected string literal was "status-light-on"

### How the Issue was addressed and how does it solve the Issue:

1.	Defined a constant in unifiprotect/binary_sensor.py to keep the duplicated message.
2.	Replaced the duplicated long message with the imported constant

String literal duplication, in the selected issue disappears with the change. Now when a developer needs to change the message he/she just have to change STATUSLIGHTON . This is a slight improvement of maintainability in homeassistant. The fix, promotes DRY principle and reduces the risk of inconsistency in the code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
