### PR TITLE
features added to world-clock with Signal and Mail

### DIFF
--- a/homeassistant/components/worldclock/sensor.py
+++ b/homeassistant/components/worldclock/sensor.py
@@ -1,32 +1,81 @@
-"""Support for showing the time in a different time zone."""
+"""Support for sending both Email and Signal messages at specific times."""
 
 from __future__ import annotations
 
-from datetime import tzinfo
+import logging
+import aiohttp
+import smtplib
+from email.mime.text import MIMEText
+from datetime import tzinfo, date
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
-    SensorEntity,
-)
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_TIME_FORMAT, DEFAULT_NAME, DEFAULT_TIME_STR_FORMAT, DOMAIN
+_LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
+# Existing config keys
+CONF_TIME_FORMAT = "time_format"
+
+# Email config
+CONF_SENDER = "sender"
+CONF_RECEIVER = "receiver"
+CONF_PASSWORD = "password"
+CONF_SMTP_SERVER = "smtp_server"  # e.g. smtp.gmail.com
+CONF_SMTP_PORT = "smtp_port"  # e.g. 587
+
+# Signal config
+CONF_SIGNAL_PHONE = "signal_phone"  # callmebot phone or unique ID
+CONF_SIGNAL_APIKEY = "signal_apikey"  # callmebot apikey
+
+# Times & messages
+CONF_TIME1_HOUR = "time1_hour"
+CONF_TIME1_MINUTE = "time1_minute"
+CONF_MSG1 = "msg1"
+
+CONF_TIME2_HOUR = "time2_hour"
+CONF_TIME2_MINUTE = "time2_minute"
+CONF_MSG2 = "msg2"
+
+CONF_TIME3_HOUR = "time3_hour"
+CONF_TIME3_MINUTE = "time3_minute"
+CONF_MSG3 = "msg3"
+
+DEFAULT_NAME = "Worldclock Sensor"
+DEFAULT_TIME_STR_FORMAT = "%H:%M"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_TIME_ZONE): cv.time_zone,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_STR_FORMAT): cv.string,
+        # Email config
+        vol.Optional(CONF_SENDER): cv.string,
+        vol.Optional(CONF_RECEIVER): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_SMTP_SERVER, default="smtp.gmail.com"): cv.string,
+        vol.Optional(CONF_SMTP_PORT, default=587): cv.positive_int,
+        # Signal config
+        vol.Optional(CONF_SIGNAL_PHONE): cv.string,
+        vol.Optional(CONF_SIGNAL_APIKEY): cv.string,
+        # Time/message 1
+        vol.Optional(CONF_TIME1_HOUR): cv.string,
+        vol.Optional(CONF_TIME1_MINUTE): cv.string,
+        vol.Optional(CONF_MSG1): cv.string,
+        # Time/message 2
+        vol.Optional(CONF_TIME2_HOUR): cv.string,
+        vol.Optional(CONF_TIME2_MINUTE): cv.string,
+        vol.Optional(CONF_MSG2): cv.string,
+        # Time/message 3
+        vol.Optional(CONF_TIME3_HOUR): cv.string,
+        vol.Optional(CONF_TIME3_MINUTE): cv.string,
+        vol.Optional(CONF_MSG3): cv.string,
     }
 )
 
@@ -37,74 +86,203 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the World clock sensor."""
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
-        )
-    )
+    """Set up the combined email + Signal sensor."""
+    time_zone = dt_util.get_time_zone(config[CONF_TIME_ZONE])
+    name = config.get(CONF_NAME)
+    time_format = config.get(CONF_TIME_FORMAT)
 
-    async_create_issue(
-        hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2025.2.0",
-        is_fixable=False,
-        issue_domain=DOMAIN,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "Worldclock",
-        },
-    )
+    # Email
+    sender = config.get(CONF_SENDER)
+    receiver = config.get(CONF_RECEIVER)
+    password = config.get(CONF_PASSWORD)
+    smtp_server = config.get(CONF_SMTP_SERVER)
+    smtp_port = config.get(CONF_SMTP_PORT)
 
+    # Signal
+    signal_phone = config.get(CONF_SIGNAL_PHONE)
+    signal_apikey = config.get(CONF_SIGNAL_APIKEY)
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up the World clock sensor entry."""
-    time_zone = await dt_util.async_get_time_zone(entry.options[CONF_TIME_ZONE])
+    # Times + messages
+    time1_hour = config.get(CONF_TIME1_HOUR)
+    time1_minute = config.get(CONF_TIME1_MINUTE)
+    msg1 = config.get(CONF_MSG1)
+
+    time2_hour = config.get(CONF_TIME2_HOUR)
+    time2_minute = config.get(CONF_TIME2_MINUTE)
+    msg2 = config.get(CONF_MSG2)
+
+    time3_hour = config.get(CONF_TIME3_HOUR)
+    time3_minute = config.get(CONF_TIME3_MINUTE)
+    msg3 = config.get(CONF_MSG3)
+
     async_add_entities(
         [
-            WorldClockSensor(
+            CombinedWorldClockSensor(
                 time_zone,
-                entry.options[CONF_NAME],
-                entry.options[CONF_TIME_FORMAT],
-                entry.entry_id,
+                name,
+                time_format,
+                sender,
+                receiver,
+                password,
+                smtp_server,
+                smtp_port,
+                signal_phone,
+                signal_apikey,
+                time1_hour,
+                time1_minute,
+                msg1,
+                time2_hour,
+                time2_minute,
+                msg2,
+                time3_hour,
+                time3_minute,
+                msg3,
             )
         ],
         True,
     )
 
 
-class WorldClockSensor(SensorEntity):
-    """Representation of a World clock sensor."""
+class CombinedWorldClockSensor(SensorEntity):
+    """Representation of a World clock sensor that sends both email & Signal messages."""
 
     _attr_icon = "mdi:clock"
-    _attr_has_entity_name = True
-    _attr_name = None
 
     def __init__(
-        self, time_zone: tzinfo | None, name: str, time_format: str, unique_id: str
+        self,
+        time_zone: tzinfo | None,
+        name: str,
+        time_format: str,
+        sender: str | None,
+        receiver: str | None,
+        password: str | None,
+        smtp_server: str,
+        smtp_port: int,
+        signal_phone: str | None,
+        signal_apikey: str | None,
+        time1_hour: str | None,
+        time1_minute: str | None,
+        msg1: str | None,
+        time2_hour: str | None,
+        time2_minute: str | None,
+        msg2: str | None,
+        time3_hour: str | None,
+        time3_minute: str | None,
+        msg3: str | None,
     ) -> None:
-        """Initialize the sensor."""
+        """Initialize the sensor and store config."""
+        self._attr_name = name
         self._time_zone = time_zone
         self._time_format = time_format
-        self._attr_unique_id = unique_id
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, unique_id)},
-            name=name,
-            entry_type=DeviceEntryType.SERVICE,
-            manufacturer="Worldclock",
-        )
+
+        self._sender = sender
+        self._receiver = receiver
+        self._password = password
+        self._smtp_server = smtp_server
+        self._smtp_port = smtp_port
+
+        self._signal_phone = signal_phone
+        self._signal_apikey = signal_apikey
+
+        self._time1_hour = time1_hour
+        self._time1_minute = time1_minute
+        self._msg1 = msg1
+
+        self._time2_hour = time2_hour
+        self._time2_minute = time2_minute
+        self._msg2 = msg2
+
+        self._time3_hour = time3_hour
+        self._time3_minute = time3_minute
+        self._msg3 = msg3
+
+        # Flags to ensure each time triggers only once per day
+        self._time1_sent_date = None
+        self._time2_sent_date = None
+        self._time3_sent_date = None
 
     async def async_update(self) -> None:
-        """Get the time and updates the states."""
-        self._attr_native_value = dt_util.now(time_zone=self._time_zone).strftime(
-            self._time_format
-        )
+        """Check the current time and send messages if matched."""
+        now_tz = dt_util.now(time_zone=self._time_zone)
+        self._attr_native_value = now_tz.strftime(self._time_format)
+
+        current_hour = now_tz.hour
+        current_minute = now_tz.minute
+        today = now_tz.date()
+
+        # 1) Check time1
+        if self._time1_hour and self._time1_minute and self._msg1:
+            if int(current_hour) == int(self._time1_hour) and int(
+                current_minute
+            ) == int(self._time1_minute):
+                if self._time1_sent_date != today:
+                    await self._send_both("Time1 Reminder", self._msg1)
+                    self._time1_sent_date = today
+
+        # 2) Check time2
+        if self._time2_hour and self._time2_minute and self._msg2:
+            if int(current_hour) == int(self._time2_hour) and int(
+                current_minute
+            ) == int(self._time2_minute):
+                if self._time2_sent_date != today:
+                    await self._send_both("Time2 Reminder", self._msg2)
+                    self._time2_sent_date = today
+
+        # 3) Check time3
+        if self._time3_hour and self._time3_minute and self._msg3:
+            if int(current_hour) == int(self._time3_hour) and int(
+                current_minute
+            ) == int(self._time3_minute):
+                if self._time3_sent_date != today:
+                    await self._send_both("Time3 Reminder", self._msg3)
+                    self._time3_sent_date = today
+
+    async def _send_both(self, subject: str, message: str) -> None:
+        """Send both an email (if configured) and a Signal message (if configured)."""
+        # 1) Send email if config is present
+        if self._sender and self._receiver and self._password:
+            await self._send_email(subject, message)
+
+        # 2) Send signal if config is present
+        if self._signal_phone and self._signal_apikey:
+            await self._send_signal(message)
+
+    async def _send_email(self, subject: str, body: str) -> None:
+        """Send an email via SMTP."""
+        try:
+            server = smtplib.SMTP(self._smtp_server, self._smtp_port)
+            server.starttls()
+            server.login(self._sender, self._password)
+
+            msg = MIMEText(body)
+            msg["Subject"] = subject
+            msg["From"] = self._sender
+            msg["To"] = self._receiver
+
+            server.sendmail(self._sender, self._receiver, msg.as_string())
+            server.quit()
+
+            _LOGGER.info("Email sent: %s", subject)
+        except Exception as exc:
+            _LOGGER.error("Error sending email: %s", exc)
+
+    async def _send_signal(self, body: str) -> None:
+        """Send a Signal message via callmebot."""
+        try:
+            # If your phone or ID has hyphens, keep them or remove them as callmebot suggests
+            # If your message has spaces, you might need to replace them with '+' or URL-encode
+            # E.g. "Hello+World" or use urllib.parse.quote_plus(body)
+            base_url = "https://signal.callmebot.com/signal/send.php"
+            api_url = f"{base_url}?phone={self._signal_phone}&apikey={self._signal_apikey}&text={body}"
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(api_url) as response:
+                    if response.status == 200:
+                        response_text = await response.text()
+                        _LOGGER.info("Signal response: %s", response_text)
+                    else:
+                        _LOGGER.error(
+                            "Signal request failed with status: %s", response.status
+                        )
+        except Exception as exc:
+            _LOGGER.error("Error sending Signal message: %s", exc)

--- a/tests/test_worldclock.py
+++ b/tests/test_worldclock.py
@@ -1,0 +1,177 @@
+"""Tests for the combined email + Signal Worldclock Sensor."""
+
+import pytest
+import smtplib
+from unittest.mock import AsyncMock, patch
+
+from datetime import datetime, timedelta
+
+import homeassistant.util.dt as dt_util
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+# We'll patch the now() method to control time in tests
+FAKE_NOW = datetime(2023, 1, 17, 12, 41, 0)  # Jan 17, 2023 12:41:00
+
+
+@pytest.fixture
+def mock_now():
+    """Fixture to patch dt_util.now() to a fixed datetime."""
+    with patch("homeassistant.util.dt.now") as mock_dt:
+        mock_dt.return_value = FAKE_NOW
+        yield mock_dt
+
+
+@pytest.fixture
+async def setup_worldclock(hass: HomeAssistant):
+    """A helper fixture to set up the combined sensor with a given config."""
+
+    async def _setup(config: dict):
+        # This sets up the sensor domain with our custom config
+        assert await async_setup_component(
+            hass,
+            "sensor",
+            {"sensor": config},
+        )
+        await hass.async_block_till_done()
+
+    return _setup
+
+
+@pytest.mark.asyncio
+async def test_basic_setup_no_times(hass: HomeAssistant, setup_worldclock, mock_now):
+    """
+    Test that the sensor sets up with minimal config (no times).
+    Verifies it doesn't crash if time1/time2/time3 are not set.
+    """
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        # Minimal email config (or partial)
+        "sender": "sender@example.com",
+        "receiver": "recv@example.com",
+        "password": "somepassword",
+        # No times for msg1/msg2/msg3
+    }
+
+    await setup_worldclock(config)
+
+    # The sensor may be named after 'name' or the default "Worldclock Sensor".
+    # If you didn't specify 'name', the entity_id might be sensor.worldclock_sensor
+    state = hass.states.get("sensor.my_combined_sensor")
+    if state is None:
+        state = hass.states.get("sensor.worldclock_sensor")
+
+    assert state is not None, "Sensor should be created even with partial config"
+    # We won't test the actual time string here, just that it doesn't crash or fail.
+
+
+@pytest.mark.asyncio
+async def test_no_trigger_when_time_not_matched(
+    hass: HomeAssistant, setup_worldclock, mock_now
+):
+    """
+    Test that if the current time does NOT match any configured times,
+    there's no email or signal call.
+    """
+    # Move FAKE_NOW to something that doesn't match 12:41
+    mock_now.return_value = FAKE_NOW + timedelta(hours=3)  # e.g., 15:41
+
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "time1_hour": "12",
+        "time1_minute": "41",
+        "msg1": "Time+to+have+breakfast",
+        "sender": "sender@example.com",
+        "receiver": "recv@example.com",
+        "password": "somepassword",
+        "signal_phone": "somephoneid",
+        "signal_apikey": "12345",
+    }
+
+    await setup_worldclock(config)
+
+    with (
+        patch("smtplib.SMTP", autospec=True) as mock_smtp_cls,
+        patch("aiohttp.ClientSession", autospec=True) as mock_session_cls,
+    ):
+        mock_smtp = mock_smtp_cls.return_value
+        mock_smtp.sendmail.return_value = None
+
+        mock_session = mock_session_cls.return_value
+        mock_session.get = AsyncMock()
+
+        await hass.helpers.entity_component.async_update_entity(
+            "sensor.worldclock_sensor"
+        )
+
+        # Because time does not match, no calls
+        assert mock_smtp.sendmail.call_count == 0
+        assert mock_session.get.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_time_format(hass: HomeAssistant, setup_worldclock, mock_now):
+    """
+    Test time_format setting, ensuring sensor state uses that format.
+    """
+    time_format = "%a, %b %d, %Y %I:%M %p"
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "time_format": time_format,
+    }
+
+    await setup_worldclock(config)
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None
+
+    expected = FAKE_NOW.strftime(time_format)
+    assert state.state == expected
+
+
+@pytest.mark.asyncio
+async def test_custom_name(hass: HomeAssistant, setup_worldclock, mock_now):
+    """
+    Ensure that if we provide a custom 'name',
+    the sensor entity_id is created accordingly.
+    """
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "name": "Custom City Sensor",
+        # Minimal config
+    }
+
+    await setup_worldclock(config)
+
+    # The entity should be "sensor.custom_city_sensor"
+    state = hass.states.get("sensor.custom_city_sensor")
+    assert state is not None, "Sensor with custom name not created"
+
+
+@pytest.mark.asyncio
+async def test_email_and_signal_config_ignored_if_no_times(
+    hass: HomeAssistant, setup_worldclock, mock_now
+):
+    """
+    If we specify email/signal config but do NOT specify any times,
+    the sensor won't ever attempt to send anything, and should pass easily.
+    """
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "sender": "example@gmail.com",
+        "receiver": "receiver@example.com",
+        "password": "dummy",
+        "signal_phone": "dummyphone",
+        "signal_apikey": "dummykey",
+        # No time1_hour/time2_hour/time3_hour => no triggers
+    }
+
+    await setup_worldclock(config)
+
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None, "Sensor not created"
+    


### PR DESCRIPTION
## Additional information
The following text needs to replace the configuration.yaml:
And this is the configuration.yaml file to make the features work:
sensor:
  - platform: worldclock # or your custom domain, e.g. "worldclock_custom"
    time_zone: "Europe/Stockholm"
    name: "My Combined Sensor"
    time_format: "%H:%M"

    # Email config:
    sender: "siri.visnagari@gmail.com"
    receiver: "teja.darbha09@gmail.com"
    password: "bijo ixds ulzz szel"
    smtp_server: "smtp.gmail.com"
    smtp_port: 587

    # Signal config:
    signal_phone: "bee609f1-f5c5-411c-a4e2-7d84b2348009" # Example from your code
    signal_apikey: "057914" # Example from your code

    # Times + messages:
    time1_hour: "13"
    time1_minute: "47"
    msg1: "Good+Morning+!+Wake+up+and+take+a+morning+walk"

    time2_hour: "13"
    time2_minute: "48"
    msg2: "Time+to+have+lunch+and+take+meds"

    time3_hour: "13"
    time3_minute: "49"
    msg3: "It's+getting+late+!+Good+night"

  
Here is the test file to be run: tests\test_worldclock.py
Working features screenshots have been added in the word document submitted. 
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

 This pull request introduces a new automation feature in Home Assistant that enables users to send scheduled reminders (e.g., “time to take your medicine”) to family members living in a different country/time zone. The automation ensures that messages are delivered at the recipient’s local time, eliminating the need to manually recalculate time differences.
The messages are sent in both mail and Signal. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
