### PR TITLE
added mail and signal notification with UI for worldclock integration

### DIFF
--- a/homeassistant/components/worldclock/sensor.py
+++ b/homeassistant/components/worldclock/sensor.py
@@ -1,32 +1,69 @@
-"""Support for showing the time in a different time zone."""
+"""Support for sending both Email and Signal messages at specific times,
+with reminder times taken from input_datetime, dynamic time zone from
+input_select.timezone, dynamic email addresses from input_text.email_sender/receiver,
+and dynamic messages from input_text.reminder_message_1/2/3.
+"""
 
 from __future__ import annotations
 
+import logging
+import aiohttp
+import smtplib
+from email.mime.text import MIMEText
 from datetime import tzinfo
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
-    SensorEntity,
-)
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
+from urllib.parse import quote_plus
 
-from .const import CONF_TIME_FORMAT, DEFAULT_NAME, DEFAULT_TIME_STR_FORMAT, DOMAIN
+_LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
+CONF_TIME_FORMAT = "time_format"
+
+# Email config
+CONF_SENDER = "sender"
+CONF_RECEIVER = "receiver"
+CONF_PASSWORD = "password"
+CONF_SMTP_SERVER = "smtp_server"
+CONF_SMTP_PORT = "smtp_port"
+
+# Signal config
+CONF_SIGNAL_PHONE = "signal_phone"
+CONF_SIGNAL_APIKEY = "signal_apikey"
+
+# Reminder messages (YAML fallback)
+CONF_MSG1 = "msg1"
+CONF_MSG2 = "msg2"
+CONF_MSG3 = "msg3"
+
+DEFAULT_NAME = "Worldclock Sensor"
+DEFAULT_TIME_STR_FORMAT = "%H:%M"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_TIME_ZONE): cv.time_zone,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_STR_FORMAT): cv.string,
+        # Email fallback
+        vol.Optional(CONF_SENDER): cv.string,
+        vol.Optional(CONF_RECEIVER): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_SMTP_SERVER, default="smtp.gmail.com"): cv.string,
+        vol.Optional(CONF_SMTP_PORT, default=587): cv.positive_int,
+        # Signal fallback
+        vol.Optional(CONF_SIGNAL_PHONE): cv.string,
+        vol.Optional(CONF_SIGNAL_APIKEY): cv.string,
+        # Fallback messages
+        vol.Optional(CONF_MSG1): cv.string,
+        vol.Optional(CONF_MSG2): cv.string,
+        vol.Optional(CONF_MSG3): cv.string,
     }
 )
 
@@ -37,74 +74,242 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the World clock sensor."""
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
-        )
-    )
+    """Set up the combined Email+Signal sensor with dynamic times, zone, addresses, messages."""
+    fallback_tz = dt_util.get_time_zone(config[CONF_TIME_ZONE])
+    name = config.get(CONF_NAME)
+    time_format = config.get(CONF_TIME_FORMAT)
 
-    async_create_issue(
-        hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2025.2.0",
-        is_fixable=False,
-        issue_domain=DOMAIN,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "Worldclock",
-        },
-    )
+    # Fallback email & signal
+    fallback_sender = config.get(CONF_SENDER)
+    fallback_receiver = config.get(CONF_RECEIVER)
+    password = config.get(CONF_PASSWORD)
+    smtp_server = config.get(CONF_SMTP_SERVER)
+    smtp_port = config.get(CONF_SMTP_PORT)
 
+    # Fallback signal
+    signal_phone = config.get(CONF_SIGNAL_PHONE)
+    signal_apikey = config.get(CONF_SIGNAL_APIKEY)
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up the World clock sensor entry."""
-    time_zone = await dt_util.async_get_time_zone(entry.options[CONF_TIME_ZONE])
+    # Fallback messages
+    msg1 = config.get(CONF_MSG1)
+    msg2 = config.get(CONF_MSG2)
+    msg3 = config.get(CONF_MSG3)
+
     async_add_entities(
         [
-            WorldClockSensor(
-                time_zone,
-                entry.options[CONF_NAME],
-                entry.options[CONF_TIME_FORMAT],
-                entry.entry_id,
+            CombinedWorldClockSensor(
+                hass,
+                fallback_tz,
+                name,
+                time_format,
+                fallback_sender,
+                fallback_receiver,
+                password,
+                smtp_server,
+                smtp_port,
+                signal_phone,
+                signal_apikey,
+                msg1,
+                msg2,
+                msg3,
             )
         ],
         True,
     )
 
 
-class WorldClockSensor(SensorEntity):
-    """Representation of a World clock sensor."""
+class CombinedWorldClockSensor(SensorEntity):
+    """World clock sensor that triggers Email & Signal at user-specified times/messages."""
 
     _attr_icon = "mdi:clock"
-    _attr_has_entity_name = True
-    _attr_name = None
 
     def __init__(
-        self, time_zone: tzinfo | None, name: str, time_format: str, unique_id: str
-    ) -> None:
-        """Initialize the sensor."""
-        self._time_zone = time_zone
+        self,
+        hass: HomeAssistant,
+        fallback_tz: tzinfo | None,
+        name: str,
+        time_format: str,
+        fallback_sender: str | None,
+        fallback_receiver: str | None,
+        password: str | None,
+        smtp_server: str,
+        smtp_port: int,
+        signal_phone: str | None,
+        signal_apikey: str | None,
+        msg1: str | None,
+        msg2: str | None,
+        msg3: str | None,
+    ):
+        """Store fallback config and placeholders."""
+        self.hass = hass
+        self._fallback_tz = fallback_tz
+        self._attr_name = name
         self._time_format = time_format
-        self._attr_unique_id = unique_id
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, unique_id)},
-            name=name,
-            entry_type=DeviceEntryType.SERVICE,
-            manufacturer="Worldclock",
-        )
+
+        self._fallback_sender = fallback_sender
+        self._fallback_receiver = fallback_receiver
+        self._password = password
+        self._smtp_server = smtp_server
+        self._smtp_port = smtp_port
+
+        self._signal_phone = signal_phone
+        self._signal_apikey = signal_apikey
+
+        # Fallback messages if user hasn't set or if input_text is blank
+        self._fallback_msg1 = msg1 or "Time to have breakfast"
+        self._fallback_msg2 = msg2 or "Time to have lunch"
+        self._fallback_msg3 = msg3 or "Time to rest and sleep"
+
+        # We'll track triggers per-minute to allow multiple triggers in same day
+        self._time1_last_minute = None
+        self._time2_last_minute = None
+        self._time3_last_minute = None
 
     async def async_update(self) -> None:
-        """Get the time and updates the states."""
-        self._attr_native_value = dt_util.now(time_zone=self._time_zone).strftime(
-            self._time_format
+        """
+        1) Dynamic time zone from input_select.timezone (fallback to YAML).
+        2) Dynamic email addresses from input_text.email_sender, input_text.email_receiver.
+        3) Dynamic messages from input_text.reminder_message_1, etc. (fallback to YAML).
+        4) Compare current time to input_datetime.reminder_timeX. Fire once/minute if matched.
+        """
+        # ---- TIME ZONE ----
+        dynamic_tz = self._fallback_tz
+        tz_state = self.hass.states.get("input_select.timezone")
+        if tz_state and tz_state.state not in ("unknown", "unavailable"):
+            chosen_zone = dt_util.get_time_zone(tz_state.state)
+            if chosen_zone:
+                dynamic_tz = chosen_zone
+
+        now_tz = dt_util.now(time_zone=dynamic_tz)
+        self._attr_native_value = now_tz.strftime(self._time_format)
+
+        hour = now_tz.hour
+        minute = now_tz.minute
+
+        # ---- EMAIL SENDER/RECEIVER ----
+        sender = self._fallback_sender
+        receiver = self._fallback_receiver
+
+        sender_state = self.hass.states.get("input_text.email_sender")
+        if sender_state and sender_state.state not in ("unknown", "unavailable"):
+            if sender_state.state.strip():
+                sender = sender_state.state.strip()
+
+        receiver_state = self.hass.states.get("input_text.email_receiver")
+        if receiver_state and receiver_state.state not in ("unknown", "unavailable"):
+            if receiver_state.state.strip():
+                receiver = receiver_state.state.strip()
+
+        # ---- MESSAGES from input_text or fallback ----
+        # If user sets input_text.reminder_message_1, we use that; else fallback
+        msg1 = (
+            self._get_custom_message("input_text.reminder_message_1")
+            or self._fallback_msg1
         )
+        msg2 = (
+            self._get_custom_message("input_text.reminder_message_2")
+            or self._fallback_msg2
+        )
+        msg3 = (
+            self._get_custom_message("input_text.reminder_message_3")
+            or self._fallback_msg3
+        )
+
+        # ---- TIMES from input_datetime ----
+        r1_hour, r1_minute = self._get_reminder_time("input_datetime.reminder_time1")
+        r2_hour, r2_minute = self._get_reminder_time("input_datetime.reminder_time2")
+        r3_hour, r3_minute = self._get_reminder_time("input_datetime.reminder_time3")
+
+        # ---- Compare current hour/minute to each reminder ----
+        # Once per minute logic
+        if r1_hour is not None and r1_minute is not None and msg1:
+            if hour == r1_hour and minute == r1_minute:
+                if self._time1_last_minute != (hour, minute):
+                    await self._send_both("Time1 Reminder", msg1, sender, receiver)
+                    self._time1_last_minute = (hour, minute)
+            else:
+                self._time1_last_minute = None
+
+        if r2_hour is not None and r2_minute is not None and msg2:
+            if hour == r2_hour and minute == r2_minute:
+                if self._time2_last_minute != (hour, minute):
+                    await self._send_both("Time2 Reminder", msg2, sender, receiver)
+                    self._time2_last_minute = (hour, minute)
+            else:
+                self._time2_last_minute = None
+
+        if r3_hour is not None and r3_minute is not None and msg3:
+            if hour == r3_hour and minute == r3_minute:
+                if self._time3_last_minute != (hour, minute):
+                    await self._send_both("Time3 Reminder", msg3, sender, receiver)
+                    self._time3_last_minute = (hour, minute)
+            else:
+                self._time3_last_minute = None
+
+    def _get_custom_message(self, entity_id: str) -> str | None:
+        """Return the user-set text from an input_text, or None if not set."""
+        state_obj = self.hass.states.get(entity_id)
+        if not state_obj or state_obj.state in ("unknown", "unavailable"):
+            return None
+        textval = state_obj.state.strip()
+        return textval if textval else None
+
+    def _get_reminder_time(self, entity_id: str) -> tuple[int | None, int | None]:
+        """Retrieve HH,MM from an input_datetime (HH:MM:SS)."""
+        state_obj = self.hass.states.get(entity_id)
+        if not state_obj or state_obj.state in ("unknown", "unavailable"):
+            return None, None
+        try:
+            parts = state_obj.state.split(":")
+            if len(parts) >= 2:
+                return int(parts[0]), int(parts[1])
+        except Exception as e:
+            _LOGGER.error("Error parsing time from %s: %s", entity_id, e)
+        return None, None
+
+    async def _send_both(
+        self, subject: str, message: str, sender: str, receiver: str
+    ) -> None:
+        """Send both an email and a Signal message if config is present."""
+        if sender and receiver and self._password:
+            await self._send_email(subject, message, sender, receiver)
+        if self._signal_phone and self._signal_apikey:
+            await self._send_signal(message)
+
+    async def _send_email(
+        self, subject: str, body: str, sender: str, receiver: str
+    ) -> None:
+        """Send an email via SMTP."""
+        try:
+            server = smtplib.SMTP(self._smtp_server, self._smtp_port)
+            server.starttls()
+            server.login(sender, self._password)
+
+            msg = MIMEText(body)
+            msg["Subject"] = subject
+            msg["From"] = sender
+            msg["To"] = receiver
+
+            server.sendmail(sender, receiver, msg.as_string())
+            server.quit()
+            _LOGGER.info("Email sent to %s (subject: %s)", receiver, subject)
+        except Exception as exc:
+            _LOGGER.error("Error sending email: %s", exc)
+
+    async def _send_signal(self, body: str) -> None:
+        """Send a Signal message via CallMeBot API."""
+        try:
+            encoded_body = quote_plus(body)
+            base_url = "https://signal.callmebot.com/signal/send.php"
+            api_url = f"{base_url}?phone={self._signal_phone}&apikey={self._signal_apikey}&text={encoded_body}"
+            async with aiohttp.ClientSession() as session:
+                async with session.get(api_url) as response:
+                    if response.status == 200:
+                        response_text = await response.text()
+                        _LOGGER.info("Signal response: %s", response_text)
+                    else:
+                        _LOGGER.error(
+                            "Signal request failed with status: %s", response.status
+                        )
+        except Exception as exc:
+            _LOGGER.error("Error sending Signal message: %s", exc)

--- a/tests/components/worldclock/test_worldclock.py
+++ b/tests/components/worldclock/test_worldclock.py
@@ -1,0 +1,177 @@
+"""Tests for the combined email + Signal Worldclock Sensor."""
+
+import pytest
+import smtplib
+from unittest.mock import AsyncMock, patch
+
+from datetime import datetime, timedelta
+
+import homeassistant.util.dt as dt_util
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+# We'll patch the now() method to control time in tests
+FAKE_NOW = datetime(2023, 1, 17, 12, 41, 0)  # Jan 17, 2023 12:41:00
+
+
+@pytest.fixture
+def mock_now():
+    """Fixture to patch dt_util.now() to a fixed datetime."""
+    with patch("homeassistant.util.dt.now") as mock_dt:
+        mock_dt.return_value = FAKE_NOW
+        yield mock_dt
+
+
+@pytest.fixture
+async def setup_worldclock(hass: HomeAssistant):
+    """A helper fixture to set up the combined sensor with a given config."""
+
+    async def _setup(config: dict):
+        # This sets up the sensor domain with our custom config
+        assert await async_setup_component(
+            hass,
+            "sensor",
+            {"sensor": config},
+        )
+        await hass.async_block_till_done()
+
+    return _setup
+
+
+@pytest.mark.asyncio
+async def test_basic_setup_no_times(hass: HomeAssistant, setup_worldclock, mock_now):
+    """
+    Test that the sensor sets up with minimal config (no times).
+    Verifies it doesn't crash if time1/time2/time3 are not set.
+    """
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        # Minimal email config (or partial)
+        "sender": "sender@example.com",
+        "receiver": "recv@example.com",
+        "password": "somepassword",
+        # No times for msg1/msg2/msg3
+    }
+
+    await setup_worldclock(config)
+
+    # The sensor may be named after 'name' or the default "Worldclock Sensor".
+    # If you didn't specify 'name', the entity_id might be sensor.worldclock_sensor
+    state = hass.states.get("sensor.my_combined_sensor")
+    if state is None:
+        state = hass.states.get("sensor.worldclock_sensor")
+
+    assert state is not None, "Sensor should be created even with partial config"
+    # We won't test the actual time string here, just that it doesn't crash or fail.
+
+
+@pytest.mark.asyncio
+async def test_no_trigger_when_time_not_matched(
+    hass: HomeAssistant, setup_worldclock, mock_now
+):
+    """
+    Test that if the current time does NOT match any configured times,
+    there's no email or signal call.
+    """
+    # Move FAKE_NOW to something that doesn't match 12:41
+    mock_now.return_value = FAKE_NOW + timedelta(hours=3)  # e.g., 15:41
+
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "time1_hour": "12",
+        "time1_minute": "41",
+        "msg1": "Time+to+have+breakfast",
+        "sender": "sender@example.com",
+        "receiver": "recv@example.com",
+        "password": "somepassword",
+        "signal_phone": "somephoneid",
+        "signal_apikey": "12345",
+    }
+
+    await setup_worldclock(config)
+
+    with (
+        patch("smtplib.SMTP", autospec=True) as mock_smtp_cls,
+        patch("aiohttp.ClientSession", autospec=True) as mock_session_cls,
+    ):
+        mock_smtp = mock_smtp_cls.return_value
+        mock_smtp.sendmail.return_value = None
+
+        mock_session = mock_session_cls.return_value
+        mock_session.get = AsyncMock()
+
+        await hass.helpers.entity_component.async_update_entity(
+            "sensor.worldclock_sensor"
+        )
+
+        # Because time does not match, no calls
+        assert mock_smtp.sendmail.call_count == 0
+        assert mock_session.get.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_time_format(hass: HomeAssistant, setup_worldclock, mock_now):
+    """
+    Test time_format setting, ensuring sensor state uses that format.
+    """
+    time_format = "%a, %b %d, %Y %I:%M %p"
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "time_format": time_format,
+    }
+
+    await setup_worldclock(config)
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None
+
+    expected = FAKE_NOW.strftime(time_format)
+    assert state.state == expected
+
+
+@pytest.mark.asyncio
+async def test_custom_name(hass: HomeAssistant, setup_worldclock, mock_now):
+    """
+    Ensure that if we provide a custom 'name',
+    the sensor entity_id is created accordingly.
+    """
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "name": "Custom City Sensor",
+        # Minimal config
+    }
+
+    await setup_worldclock(config)
+
+    # The entity should be "sensor.custom_city_sensor"
+    state = hass.states.get("sensor.custom_city_sensor")
+    assert state is not None, "Sensor with custom name not created"
+
+
+@pytest.mark.asyncio
+async def test_email_and_signal_config_ignored_if_no_times(
+    hass: HomeAssistant, setup_worldclock, mock_now
+):
+    """
+    If we specify email/signal config but do NOT specify any times,
+    the sensor won't ever attempt to send anything, and should pass easily.
+    """
+    config = {
+        "platform": "worldclock",
+        "time_zone": "Europe/Stockholm",
+        "sender": "example@gmail.com",
+        "receiver": "receiver@example.com",
+        "password": "dummy",
+        "signal_phone": "dummyphone",
+        "signal_apikey": "dummykey",
+        # No time1_hour/time2_hour/time3_hour => no triggers
+    }
+
+    await setup_worldclock(config)
+
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None, "Sensor not created"
+    


### PR DESCRIPTION
## worldclock integration
 This pull request introduces a new automation feature in Home Assistant that enables users to send scheduled reminders (e.g., “time to take your medicine”) to family members living in a different country/time zone. The automation ensures that messages are delivered at the recipient’s local time, eliminating the need to manually recalculate time differences.
The messages are sent in both mail and Signal. 
## configuration.yaml
-/config/configuration.yaml
```
########################################
# configuration.yaml
########################################

# ---------- 1) Time Zone & Email Helpers ----------
input_select:
  timezone:
    name: "Time Zone"
    options:
      - "UTC"
      - "Europe/Stockholm"
      - "America/New_York"
      - "Asia/Kolkata"
      - "Australia/Sydney"
    initial: "Europe/Stockholm"

input_text:
  email_receiver:
    name: "Email Receiver"
    initial: "venkatpendyala36@gmail.com"
  reminder_message_1:
    name: "Reminder Message 1"
    initial: "Time to have breakfast"
    max: 255
  reminder_message_2:
    name: "Reminder Message 2"
    initial: "Time to have lunch"
    max: 255
  reminder_message_3:
    name: "Reminder Message 3"
    initial: "Time to rest and sleep"
    max: 255

# ---------- 3) Times for Reminders ----------
input_datetime:
  reminder_time1:
    name: "Reminder Time 1"
    has_date: false
    has_time: true
    initial: "08:00:00"

  reminder_time2:
    name: "Reminder Time 2"
    has_date: false
    has_time: true
    initial: "13:00:00"

  reminder_time3:
    name: "Reminder Time 3"
    has_date: false
    has_time: true
    initial: "20:00:00"

# ---------- 4) The Combined Sensor (using your updated sensor.py) ----------
sensor:
  - platform: worldclock
    time_zone: "Europe/Stockholm"       # Fallback if input_select.timezone is unknown
    name: "My Combined Sensor"
    time_format: "%H:%M"

    # Email fallback (YAML)
    sender: "siri.visnagari@gmail.com"
    receiver: "venkatpendyala36@gmail.com"
    password: "bijo ixds ulzz szel"
    smtp_server: "smtp.gmail.com"
    smtp_port: 587

    # Signal (optional)
    signal_phone: "92241908-b787-4896-afc6-92eff6d8e5ff"
    signal_apikey: "389946"

    # Fallback messages in YAML (if user doesn't define them in input_text)
    msg1: "Breakfast fallback"
    msg2: "Lunch fallback"
    msg3: "Sleep fallback"

recorder:
  purge_keep_days: 7

  include:
    domains:
      - input_text
      - input_datetime
      - input_select
      # etc.

```
## automations.yaml
-/config/automations.yaml
```
########################################
# automations.yaml
########################################

automation:
  - alias: "Force Combined Sensor Update on UI Changes"
    description: "Call update_entity whenever user changes time zone, email, or messages."
    trigger:
      - platform: state
        entity_id:
          - input_select.timezone
          - input_text.email_sender
          - input_text.email_receiver
          - input_text.reminder_message_1
          - input_text.reminder_message_2
          - input_text.reminder_message_3
    action:
      - service: homeassistant.update_entity
        target:
          entity_id: sensor.my_combined_sensor
```





<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
