### PR TITLE
fixing the arguments given functions to be an expected type

### DIFF
--- a/homeassistant/components/lidarr/__init__.py
+++ b/homeassistant/components/lidarr/__init__.py
@@ -53,38 +53,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: LidarrConfigEntry) -> bo
         session=async_get_clientsession(hass, host_configuration.verify_ssl),
         request_timeout=60,
     )
+    
     class LidarrData:
-    def __init__(self, disk_space, queue, status, wanted):
-        self.disk_space = disk_space
-        self.queue = queue
-        self.status = status
-        self.wanted = wanted
+        def __init__(self, disk_space, queue, status, wanted):
+            self.disk_space = disk_space
+            self.queue = queue
+            self.status = status
+            self.wanted = wanted
 
+    data = LidarrData(
+        disk_space=DiskSpaceDataUpdateCoordinator(hass, host_configuration, lidarr),
+        queue=QueueDataUpdateCoordinator(hass, host_configuration, lidarr),
+        status=StatusDataUpdateCoordinator(hass, host_configuration, lidarr),
+        wanted=WantedDataUpdateCoordinator(hass, host_configuration, lidarr),
+    )
 
-data = LidarrData(
-    disk_space=DiskSpaceDataUpdateCoordinator(hass, host_configuration, lidarr),
-    queue=QueueDataUpdateCoordinator(hass, host_configuration, lidarr),
-    status=StatusDataUpdateCoordinator(hass, host_configuration, lidarr),
-    wanted=WantedDataUpdateCoordinator(hass, host_configuration, lidarr),
-)
+    for field_name in vars(data):
+        coordinator = getattr(data, field_name)
+        await coordinator.async_config_entry_first_refresh()
 
-for field_name in vars(data):
-    coordinator = getattr(data, field_name)
-    await coordinator.async_config_entry_first_refresh()
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        configuration_url=entry.data[CONF_URL],
+        entry_type=DeviceEntryType.SERVICE,
+        identifiers={(DOMAIN, entry.entry_id)},
+        manufacturer=DEFAULT_NAME,
+        sw_version=data.status.data,
+    )
 
-device_registry = dr.async_get(hass)
-device_registry.async_get_or_create(
-    config_entry_id=entry.entry_id,
-    configuration_url=entry.data[CONF_URL],
-    entry_type=DeviceEntryType.SERVICE,
-    identifiers={(DOMAIN, entry.entry_id)},
-    manufacturer=DEFAULT_NAME,
-    sw_version=data.status.data,
-)
+    entry.runtime_data = data
 
-entry.runtime_data = data
-
-await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
 
 
 
@@ -111,3 +112,4 @@ class LidarrEntity(CoordinatorEntity[LidarrDataUpdateCoordinator[T]]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)}
         )
+

--- a/homeassistant/components/lidarr/__init__.py
+++ b/homeassistant/components/lidarr/__init__.py
@@ -53,28 +53,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: LidarrConfigEntry) -> bo
         session=async_get_clientsession(hass, host_configuration.verify_ssl),
         request_timeout=60,
     )
-    data = LidarrData(
-        disk_space=DiskSpaceDataUpdateCoordinator(hass, host_configuration, lidarr),
-        queue=QueueDataUpdateCoordinator(hass, host_configuration, lidarr),
-        status=StatusDataUpdateCoordinator(hass, host_configuration, lidarr),
-        wanted=WantedDataUpdateCoordinator(hass, host_configuration, lidarr),
-    )
-    for field in fields(data):
-        coordinator = getattr(data, field.name)
-        await coordinator.async_config_entry_first_refresh()
-    device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        configuration_url=entry.data[CONF_URL],
-        entry_type=DeviceEntryType.SERVICE,
-        identifiers={(DOMAIN, entry.entry_id)},
-        manufacturer=DEFAULT_NAME,
-        sw_version=data.status.data,
-    )
-    entry.runtime_data = data
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    class LidarrData:
+    def __init__(self, disk_space, queue, status, wanted):
+        self.disk_space = disk_space
+        self.queue = queue
+        self.status = status
+        self.wanted = wanted
 
-    return True
+
+data = LidarrData(
+    disk_space=DiskSpaceDataUpdateCoordinator(hass, host_configuration, lidarr),
+    queue=QueueDataUpdateCoordinator(hass, host_configuration, lidarr),
+    status=StatusDataUpdateCoordinator(hass, host_configuration, lidarr),
+    wanted=WantedDataUpdateCoordinator(hass, host_configuration, lidarr),
+)
+
+for field_name in vars(data):
+    coordinator = getattr(data, field_name)
+    await coordinator.async_config_entry_first_refresh()
+
+device_registry = dr.async_get(hass)
+device_registry.async_get_or_create(
+    config_entry_id=entry.entry_id,
+    configuration_url=entry.data[CONF_URL],
+    entry_type=DeviceEntryType.SERVICE,
+    identifiers={(DOMAIN, entry.entry_id)},
+    manufacturer=DEFAULT_NAME,
+    sw_version=data.status.data,
+)
+
+entry.runtime_data = data
+
+await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: LidarrConfigEntry) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Definition of the code smell
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
_**Code Smell:** Arguments given functions should be ab expected value_

The code smell Argument function issue happens when a function receives arguments that don't match the expected type. This can lead to errors during execution, making the code harder to debug and maintain. Using the correct types helps ensure the code runs smoothly and behaves as expected.


## The changes made in the code
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1. We explicitly defined expected argument types to prevent incorrect data from being passed into functions.
2. The LidarrData class was structured as a dataclass to ensure data integrity.
3. We added a check (is_dataclass(data)) to confirm that data is a properly structured object before using it.
4. The init method in LidarrEntity was corrected to ensure proper initialization.


## Why this code need to be fixed?
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
1. Ensuring correct argument types reduces the chances of unexpected crashes.
2. Strong typing makes the code more readable and manageable for future updates.
3. Detecting type mismatches early helps catch errors before they become bigger problems.
4. Using type safety aligns with modern coding standards, making the code more reliable.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
