### PR TITLE
Exception and based excepotion should not be raised

### DIFF
--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for Amcrest IP camera binary sensors."""
 
-from __future__ import annotations
+from _future_ import annotations
 
 from contextlib import suppress
 from dataclasses import dataclass
@@ -44,7 +44,7 @@ class AmcrestSensorEntityDescription(BinarySensorEntityDescription):
     should_poll: bool = False
 
 
-_LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger(name_)
 
 SCAN_INTERVAL = timedelta(seconds=BINARY_SENSOR_SCAN_INTERVAL_SECS)
 _ONLINE_SCAN_INTERVAL = timedelta(seconds=60 - BINARY_SENSOR_SCAN_INTERVAL_SECS)
@@ -135,7 +135,6 @@ def check_binary_sensors(value: list[str]) -> list[str]:
 
 async def async_setup_platform(
     hass: HomeAssistant,
-    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
@@ -159,7 +158,7 @@ async def async_setup_platform(
 class AmcrestBinarySensor(BinarySensorEntity):
     """Binary sensor for Amcrest camera."""
 
-    def __init__(
+    def _init_(
         self,
         name: str,
         device: AmcrestDevice,
@@ -194,7 +193,7 @@ class AmcrestBinarySensor(BinarySensorEntity):
 
         if self._api.available:
             # Send a command to the camera to test if we can still communicate with it.
-            # Override of Http.async_command() in __init__.py will set self._api.available
+            # Override of Http.async_command() in _init_.py will set self._api.available
             # accordingly.
             with suppress(AmcrestError):
                 await self._api.async_current_time

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for Amcrest IP camera binary sensors."""
 
-from _future_ import annotations
+from __future__ import annotations
 
 from contextlib import suppress
 from dataclasses import dataclass
@@ -44,7 +44,7 @@ class AmcrestSensorEntityDescription(BinarySensorEntityDescription):
     should_poll: bool = False
 
 
-LOGGER = logging.getLogger(name_)
+_LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=BINARY_SENSOR_SCAN_INTERVAL_SECS)
 _ONLINE_SCAN_INTERVAL = timedelta(seconds=60 - BINARY_SENSOR_SCAN_INTERVAL_SECS)
@@ -158,7 +158,7 @@ async def async_setup_platform(
 class AmcrestBinarySensor(BinarySensorEntity):
     """Binary sensor for Amcrest camera."""
 
-    def _init_(
+    def __init__(
         self,
         name: str,
         device: AmcrestDevice,
@@ -193,7 +193,7 @@ class AmcrestBinarySensor(BinarySensorEntity):
 
         if self._api.available:
             # Send a command to the camera to test if we can still communicate with it.
-            # Override of Http.async_command() in _init_.py will set self._api.available
+            # Override of Http.async_command() in __init__.py will set self._api.available
             # accordingly.
             with suppress(AmcrestError):
                 await self._api.async_current_time

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -1,6 +1,6 @@
 """Support for Amcrest IP cameras."""
 
-from __future__ import annotations
+from _future_ import annotations
 
 import asyncio
 from collections.abc import Callable
@@ -43,7 +43,7 @@ from .helpers import log_update_error, service_signal
 if TYPE_CHECKING:
     from . import AmcrestDevice
 
-_LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger(name_)
 
 SCAN_INTERVAL = timedelta(seconds=15)
 
@@ -125,7 +125,6 @@ _BOOL_TO_STATE = {True: STATE_ON, False: STATE_OFF}
 
 async def async_setup_platform(
     hass: HomeAssistant,
-    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
@@ -154,9 +153,9 @@ class AmcrestCam(Camera):
     _attr_should_poll = True  # Cameras default to False
     _attr_supported_features = CameraEntityFeature.ON_OFF | CameraEntityFeature.STREAM
 
-    def __init__(self, name: str, device: AmcrestDevice, ffmpeg: FFmpegManager) -> None:
+    def _init_(self, name: str, device: AmcrestDevice, ffmpeg: FFmpegManager) -> None:
         """Initialize an Amcrest camera."""
-        super().__init__()
+        super()._init_()
         self._name = name
         self._api = device.api
         self._ffmpeg = ffmpeg
@@ -496,8 +495,8 @@ class AmcrestCam(Camera):
         max_tries = 3
         for tries in range(max_tries, 0, -1):
             try:
-                await getattr(self, f"_async_set_{func}")(value)
-                new_value = await getattr(self, f"_async_get_{func}")()
+                await getattr(self, f"async_set{func}")(value)
+                new_value = await getattr(self, f"async_get{func}")()
                 if new_value != value:
                     raise AmcrestCommandFailed  # noqa: TRY301
             except (AmcrestError, AmcrestCommandFailed) as error:

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -1,6 +1,6 @@
 """Support for Amcrest IP cameras."""
 
-from _future_ import annotations
+from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
@@ -43,7 +43,7 @@ from .helpers import log_update_error, service_signal
 if TYPE_CHECKING:
     from . import AmcrestDevice
 
-LOGGER = logging.getLogger(name_)
+_LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=15)
 
@@ -153,9 +153,9 @@ class AmcrestCam(Camera):
     _attr_should_poll = True  # Cameras default to False
     _attr_supported_features = CameraEntityFeature.ON_OFF | CameraEntityFeature.STREAM
 
-    def _init_(self, name: str, device: AmcrestDevice, ffmpeg: FFmpegManager) -> None:
+    def __init__(self, name: str, device: AmcrestDevice, ffmpeg: FFmpegManager) -> None:
         """Initialize an Amcrest camera."""
-        super()._init_()
+        super().__init__()
         self._name = name
         self._api = device.api
         self._ffmpeg = ffmpeg

--- a/homeassistant/components/amcrest/sensor.py
+++ b/homeassistant/components/amcrest/sensor.py
@@ -1,6 +1,6 @@
 """Support for Amcrest IP camera sensors."""
 
-from _future_ import annotations
+from __future__ import annotations
 
 from datetime import timedelta
 import logging
@@ -21,7 +21,7 @@ from .helpers import log_update_error, service_signal
 if TYPE_CHECKING:
     from . import AmcrestDevice
 
-LOGGER = logging.getLogger(name_)
+_LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=SENSOR_SCAN_INTERVAL_SECS)
 
@@ -70,7 +70,7 @@ async def async_setup_platform(
 class AmcrestSensor(SensorEntity):
     """A sensor implementation for Amcrest IP camera."""
 
-    def _init_(
+    def __init__(
         self, name: str, device: AmcrestDevice, description: SensorEntityDescription
     ) -> None:
         """Initialize a sensor for Amcrest camera."""

--- a/homeassistant/components/amcrest/sensor.py
+++ b/homeassistant/components/amcrest/sensor.py
@@ -1,6 +1,6 @@
 """Support for Amcrest IP camera sensors."""
 
-from __future__ import annotations
+from _future_ import annotations
 
 from datetime import timedelta
 import logging
@@ -21,7 +21,7 @@ from .helpers import log_update_error, service_signal
 if TYPE_CHECKING:
     from . import AmcrestDevice
 
-_LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger(name_)
 
 SCAN_INTERVAL = timedelta(seconds=SENSOR_SCAN_INTERVAL_SECS)
 
@@ -47,7 +47,6 @@ SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
 async def async_setup_platform(
     hass: HomeAssistant,
-    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
@@ -71,7 +70,7 @@ async def async_setup_platform(
 class AmcrestSensor(SensorEntity):
     """A sensor implementation for Amcrest IP camera."""
 
-    def __init__(
+    def _init_(
         self, name: str, device: AmcrestDevice, description: SensorEntityDescription
     ) -> None:
         """Initialize a sensor for Amcrest camera."""

--- a/homeassistant/components/starline/config_flow.py
+++ b/homeassistant/components/starline/config_flow.py
@@ -28,6 +28,10 @@ from .const import (
 )
 
 
+class StarlineAuthenticationError(Exception):
+    """Raised when a StarLine authentication error occurs."""
+
+
 class StarlineFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a StarLine config flow."""
 
@@ -218,7 +222,7 @@ class StarlineFlowHandler(ConfigFlow, domain=DOMAIN):
                 self._captcha_image = data["captchaImg"]
                 return self._async_form_auth_captcha(error)
 
-            raise Exception(data)  # noqa: TRY002, TRY301
+            raise StarlineAuthenticationError(data)  # noqa: TRY002, TRY301
         except Exception as err:  # noqa: BLE001
             _LOGGER.error("Error auth user: %s", err)
             return self._async_form_auth_user(ERROR_AUTH_USER)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## StarLine Authentication Error Fix
This update addresses a specific code smell in the StarLine configuration flow where a generic Exception was being raised for authentication errors. Using a generic exception does not provide sufficient context about the error, making it harder for developers to debug and maintain the code. To resolve this issue, we introduced a custom exception, StarlineAuthenticationError, which replaces the generic exception, thus making the error handling more precise and descriptive.

In the original implementation, the code raised a generic exception with the following line:

raise Exception(data)  # noqa: TRY002, TRY301

This approach was problematic because it did not clearly indicate the type of error encountered during the authentication process. A generic exception can obscure the root cause of an issue and complicate error management. By switching to a specific exception, developers can now more easily identify and handle errors related to StarLine authentication.

To implement the fix, we created the StarlineAuthenticationError class and replaced the generic exception with an instance of this new class. The updated code now raises:

raise StarlineAuthenticationError(data)  # noqa: TRY002, TRY301

This change improves clarity, facilitates better debugging, and enhances maintainability by adhering to best practices in error handling. Overall, the fix makes the authentication flow more robust and ensures that errors are managed in a more controlled and transparent manner. For more details on the changes, please refer to the commit history.
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
