### PR TITLE
Rename iOS view classes to comply with naming convention

### DIFF
--- a/homeassistant/components/ios/__init__.py
+++ b/homeassistant/components/ios/__init__.py
@@ -295,14 +295,15 @@ async def async_setup_entry(
     """Set up an iOS entry."""
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    hass.http.register_view(iOSIdentifyDeviceView(hass.config.path(CONFIGURATION_FILE)))
-    hass.http.register_view(iOSPushConfigView(hass.data[DOMAIN][CONF_USER][CONF_PUSH]))
-    hass.http.register_view(iOSConfigView(hass.data[DOMAIN][CONF_USER]))
+    # Updated class references:
+    hass.http.register_view(IosIdentifyDeviceView(hass.config.path(CONFIGURATION_FILE)))
+    hass.http.register_view(IosPushConfigView(hass.data[DOMAIN][CONF_USER][CONF_PUSH]))
+    hass.http.register_view(IosConfigView(hass.data[DOMAIN][CONF_USER]))
 
     return True
 
 
-class iOSPushConfigView(HomeAssistantView):
+class IosPushConfigView(HomeAssistantView):
     """A view that provides the push categories configuration."""
 
     url = "/api/ios/push"
@@ -318,7 +319,7 @@ class iOSPushConfigView(HomeAssistantView):
         return self.json(self.push_config)
 
 
-class iOSConfigView(HomeAssistantView):
+class IosConfigView(HomeAssistantView):
     """A view that provides the whole user-defined configuration."""
 
     url = "/api/ios/config"
@@ -334,7 +335,7 @@ class iOSConfigView(HomeAssistantView):
         return self.json(self.config)
 
 
-class iOSIdentifyDeviceView(HomeAssistantView):
+class IosIdentifyDeviceView(HomeAssistantView):
     """A view that accepts device identification requests."""
 
     url = "/api/ios/identify"


### PR DESCRIPTION
## Class names should comply with a naming convention
The view classes within the iOS component did not adhere to the prescribed naming convention (^?([A-Z][a-zA-Z0-9]|[a-z_][a-z0-9_])$). Specifically, the classes iOSPushConfigView, iOSConfigView, and iOSIdentifyDeviceView use a mix of uppercase and lowercase letters in a way that is inconsistent with our standard. This naming inconsistency can lead to confusion, reduce code readability, and make maintenance more challenging over time.

To resolve this issue, we have renamed the affected classes to align with our naming convention. The changes are as follows:

iOSPushConfigView has been renamed to IosPushConfigView.
iOSConfigView has been renamed to IosConfigView.
iOSIdentifyDeviceView has been renamed to IosIdentifyDeviceView.

In addition to renaming the classes, all references to these classes in the project (specifically within the async_setup_entry function) have been updated to reflect the new names. This refactoring ensures that our codebase remains consistent, improves readability, and adheres to the established coding standards.